### PR TITLE
Fix Parsing Workflow Execution

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -71,6 +71,25 @@ export class Eko {
   }
 
   public async execute(workflow: Workflow, callback?: WorkflowCallback): Promise<NodeOutput[]> {
+    // Inject LLM provider at workflow level
+    workflow.llmProvider = this.llmProvider;
+
+    // Process each node's action
+    for (const node of workflow.nodes) {
+      if (node.action.type === 'prompt') {
+        // Inject LLM provider
+        node.action.llmProvider = this.llmProvider;
+
+        // Resolve tools
+        node.action.tools = node.action.tools.map(tool => {
+          if (typeof tool === 'string') {
+            return this.toolRegistry.getTool(tool);
+          }
+          return tool;
+        });
+      }
+    }
+
     return await workflow.execute(callback);
   }
 

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -91,7 +91,7 @@ export class ActionImpl implements Action {
     public name: string,
     public description: string,
     public tools: Tool<any, any>[],
-    private llmProvider: LLMProvider,
+    private llmProvider: LLMProvider | undefined,
     private llmConfig?: LLMParameters,
     config?: { maxRounds?: number }
   ) {
@@ -257,6 +257,9 @@ export class ActionImpl implements Action {
     this.handleHistoryImageMessages(messages);
 
     // Wait for stream to complete
+    if (!this.llmProvider) {
+      throw new Error('LLM provider not set');
+    }
     await this.llmProvider.generateStream(messages, params, handler);
 
     // Wait for tool execution to complete if it was started
@@ -319,6 +322,7 @@ export class ActionImpl implements Action {
     context: ExecutionContext,
     outputSchema?: unknown
   ): Promise<unknown> {
+    console.log(`Executing action started: ${this.name}`);
     // Create return tool with output schema
     const returnTool = createReturnTool(this.name, output.description, outputSchema);
 
@@ -488,7 +492,7 @@ export class ActionImpl implements Action {
     name: string,
     description: string,
     tools: Tool<any, any>[],
-    llmProvider: LLMProvider,
+    llmProvider: LLMProvider | undefined,
     llmConfig?: LLMParameters
   ): Action {
     return new ActionImpl('prompt', name, description, tools, llmProvider, llmConfig);

--- a/src/types/action.types.ts
+++ b/src/types/action.types.ts
@@ -43,5 +43,6 @@ export interface Action {
   name: string;
   description: string;
   execute: (input: NodeInput, output: NodeOutput, context: ExecutionContext) => Promise<unknown>;
-  tools: Tool<any, any>[];
+  tools: Array<Tool<any, any> | string>; // Allow both Tool objects and tool names
+  llmProvider?: LLMProvider;
 }


### PR DESCRIPTION

## Description
This pull request addresses an issue where workflows were not executable after being serialized and de-serialized. The changes ensure that the workflow remains executable throughout this process.

## Motivation and Context
This change is required to maintain the integrity and functionality of workflows after serialization and de-serialization. It resolves a bug that was causing workflows to become non-executable, impacting the system's reliability.

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Type of Change
- [x] fix: Bug fix

## Breaking Changes
Workflow DSL updated: only tool names, but not tool descriptions/input schemas, are now included in workflow DSL. The reason is that we cannot recover executable tool definitions from the descriptions in any case, which would only increase the verbosity of DSL.

## Additional Notes
N/A

## Reviewer Notes
Please verify the workflow execution after serialization and de-serialization to ensure the fix is effective.
