### PR TITLE
feature: not always open new window

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -27,8 +27,10 @@ export class Eko {
   private workflowGeneratorMap = new Map<Workflow, WorkflowGenerator>();
   private ekoConfig: EkoConfig;
 
-  constructor(llmConfig: LLMConfig, ekoConfig: EkoConfig) {
-    this.ekoConfig = ekoConfig;
+  constructor(llmConfig: LLMConfig, ekoConfig?: EkoConfig) {
+    this.ekoConfig = ekoConfig ? ekoConfig : {
+      alwaysOpenNewWindow: false,
+    }
     if (typeof llmConfig == 'string') {
       this.llmProvider = new ClaudeProvider(llmConfig);
     } else if ('llm' in llmConfig) {

--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -28,9 +28,10 @@ export class Eko {
   private ekoConfig: EkoConfig;
 
   constructor(llmConfig: LLMConfig, ekoConfig?: EkoConfig) {
+    console.log("ekoConfig: " + ekoConfig);
     this.ekoConfig = ekoConfig ? ekoConfig : {
       alwaysOpenNewWindow: false,
-    }
+    };
     if (typeof llmConfig == 'string') {
       this.llmProvider = new ClaudeProvider(llmConfig);
     } else if ('llm' in llmConfig) {

--- a/src/extension/tools/web_search.ts
+++ b/src/extension/tools/web_search.ts
@@ -47,8 +47,14 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
     }
     let taskId = new Date().getTime() + '';
     let searchs = [{ url: url as string, keyword: query as string }];
-    let window = await chrome.windows.getCurrent();
-    let searchInfo = await deepSearch(taskId, searchs, maxResults || 5, window);
+    let searchInfo: any;
+    console.log("context.ekoConfig: "+context.ekoConfig);
+    if (context.ekoConfig.alwaysOpenNewWindow) {
+      searchInfo = await deepSearch(taskId, searchs, maxResults || 5);
+    } else {
+      let window = await chrome.windows.getCurrent();
+      searchInfo = await deepSearch(taskId, searchs, maxResults || 5, window);
+    }
     let links = searchInfo.result[0]?.links || [];
     return links.filter((s: any) => s.content) as WebSearchResult[];
   }

--- a/src/extension/tools/web_search.ts
+++ b/src/extension/tools/web_search.ts
@@ -47,7 +47,8 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
     }
     let taskId = new Date().getTime() + '';
     let searchs = [{ url: url as string, keyword: query as string }];
-    let searchInfo = await deepSearch(taskId, searchs, maxResults || 5);
+    let window = await chrome.windows.getCurrent();
+    let searchInfo = await deepSearch(taskId, searchs, maxResults || 5, window);
     let links = searchInfo.result[0]?.links || [];
     return links.filter((s: any) => s.content) as WebSearchResult[];
   }

--- a/src/models/workflow.ts
+++ b/src/models/workflow.ts
@@ -38,10 +38,11 @@ export class WorkflowImpl implements Workflow {
       const node = this.getNode(nodeId);
 
       // Execute the node's action
-      const context = {
+      const context: ExecutionContext = {
         __skip: false,
         __abort: false,
         workflow: this,
+        ekoConfig: {alwaysOpenNewWindow: false},
         variables: this.variables,
         llmProvider: this.llmProvider as LLMProvider,
         tools: new Map(node.action.tools.map(tool => [tool.name, tool])),

--- a/src/types/action.types.ts
+++ b/src/types/action.types.ts
@@ -29,8 +29,13 @@ export interface Property {
   properties?: Properties;
 }
 
+export interface EkoConfig {
+  alwaysOpenNewWindow: boolean;
+}
+
 export interface ExecutionContext {
   llmProvider: LLMProvider;
+  ekoConfig: EkoConfig;
   variables: Map<string, unknown>;
   workflow?: Workflow;
   tools?: Map<string, Tool<any, any>>;

--- a/src/types/eko.types.ts
+++ b/src/types/eko.types.ts
@@ -19,7 +19,7 @@ export interface OpenaiConfig {
 
 export type ClaudeApiKey = string;
 
-export type EkoConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | LLMProvider;
+export type LLMConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | LLMProvider;
 
 export interface EkoInvokeParam {
   tools?: Array<string> | Array<Tool<any, any>>;


### PR DESCRIPTION
在之前的版本中，`web_search`和`export_file`工具会总是打开新窗口，这个 PR 修改了一部分代码，让着两个工具可以在已有的窗口进行操作。

这个 PR 还对`Eko`类增加了一个可选的`ekoConfig`参数，其中的`alwaysOpenNewWindow`字段可以决定是否总是在新窗口打开。

然而，当我尝试把代码加载到浏览器插件时出现了问题。当我尝试 prompt `Search Sam Altman's information and summarize it into markdown format for export`时，在 popup 窗口的 console 总是会在开头打印`ekoConfig: undefined`。这看起来是`Eko.constructor()`打印的，提示浏览器插件的相关代码在调用 Eko 框架时出现了不兼容的情况。

由于我对于浏览器插件的代码并不熟悉，所以请求对这块业务熟悉的人拉取这个 PR 的代码进行调试。

---

In previous versions, the `web_search` and `export_file` tools would always open new windows. This pull request (PR) modifies part of the code to allow these two tools to operate within existing windows.

Additionally, this PR introduces an optional `ekoConfig` parameter to the `Eko` class, which includes an `alwaysOpenNewWindow` field that determines whether to always open a new window.

However, issues arose when I tried to load the code into the browser extension. When I attempted to prompt with "Search Sam Altman's information and summarize it into markdown format for export," the console in the popup window always printed `ekoConfig: undefined` at the beginning. It seems that this was printed by `Eko.constructor()`, suggesting an incompatibility in the browser extension's relevant code when calling the Eko framework.

Since I am not familiar with the code for browser extensions, I request that someone who is familiar with this area pull the code for this PR and debug it.