### PR TITLE
feat: add `cancel_workflow` tool

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,7 @@ export default [
         tsconfig: './tsconfig.json',
         declaration: true,
         declarationDir: 'dist',
-        include: ['src/types/*', 'src/extension/**/*'],
+        include: ['src/types/*', 'src/extension/**/*', 'src/universal_tools/**/*'],
         exclude: ['src/extension/script']
       }),
       copy({

--- a/src/extension/tools/index.ts
+++ b/src/extension/tools/index.ts
@@ -10,6 +10,8 @@ import { TabManagement } from './tab_management';
 import { WebSearch } from './web_search';
 import { RequestLogin } from './request_login';
 
+export * from '../../universal_tools';
+
 export {
   BrowserUse,
   ElementClick,

--- a/src/nodejs/tools/index.ts
+++ b/src/nodejs/tools/index.ts
@@ -1,3 +1,5 @@
+export * from '../../universal_tools';
+
 export { CommandExecute } from './command_execute';
 export { FileRead } from './file_read';
 export { FileWrite } from './file_write';

--- a/src/services/workflow/generator.ts
+++ b/src/services/workflow/generator.ts
@@ -93,6 +93,18 @@ export class WorkflowGenerator {
       }
     }
 
+    // Forcibly add special tools
+    const specialTools = [
+      "cancel_workflow",
+    ]
+    for (const node of workflowData.nodes) {
+      for (const tool of specialTools) {
+        if (!node.action.tools.includes(tool)) {
+          node.action.tools.push(tool);
+        }
+      }
+    }
+
     // Generate a new UUID if not provided
     if (!workflowData.id) {
       workflowData.id = uuidv4();

--- a/src/types/tools.types.ts
+++ b/src/types/tools.types.ts
@@ -111,3 +111,7 @@ export interface ElementRect {
   width?: number;
   height?: number;
 }
+
+export interface CancelWorkflowInput {
+  reason: string;
+}

--- a/src/universal_tools/cancel_workflow.ts
+++ b/src/universal_tools/cancel_workflow.ts
@@ -1,0 +1,33 @@
+import { CancelWorkflowInput } from '../types/tools.types';
+import { Tool, InputSchema, ExecutionContext } from '../types/action.types';
+
+export class CancelWorkflow implements Tool<CancelWorkflowInput, void> {
+  name: string;
+  description: string;
+  input_schema: InputSchema;
+
+  constructor() {
+    this.name = 'cancel_workflow';
+    this.description = 'Cancel the workflow. If any tool consistently encounters exceptions, invoke this tool to cancel the workflow.';
+    this.input_schema = {
+      type: 'object',
+      properties: {
+        reason: {
+          type: 'string',
+          description: 'Why the workflow should be cancelled.',
+        },
+      },
+      required: ['reason'],
+    };
+  }
+
+  async execute(context: ExecutionContext, params: CancelWorkflowInput): Promise<void> {
+    if (typeof params !== 'object' || params === null || !params.reason) {
+      throw new Error('Invalid parameters. Expected an object with a "reason" property.');
+    }
+    const reason = params.reason;
+    console.log("The workflow has been cancelled because: " + reason);
+    await context.workflow?.cancel();
+    return;
+  }
+}

--- a/src/universal_tools/index.ts
+++ b/src/universal_tools/index.ts
@@ -1,0 +1,5 @@
+import { CancelWorkflow } from "./cancel_workflow";
+
+export {
+    CancelWorkflow,
+}


### PR DESCRIPTION
这个 PR 增加了一个 `cancel_workflow` 的工具，并强制在每个 SubTask 都添加这个工具，这样 Eko 在遇到工具运行失败时会自动调用这个工具来结束工作流。这可以通过以下方法验证：
1. 在 `web_search` 工具中加入一行代码，让其在执行的时候会抛出一个异常；
2. 编译成浏览器插件，然后运行这个 prompt `Search Sam Altman's information and summarize it into markdown format for export`；
3. 观察 Popup 的日志；
4. 期望行为是 Eko 在尝试几次调用工具失败后会调用`cancel_workflow`工具来取消工作流。

对于工具调用之外的异常，经过测试发现目前的实现可以实现需求所描述的快速失败。

---

This PR introduces a `cancel_workflow` tool and enforces its addition to every SubTask. This allows the Eko to automatically invoke this tool to terminate the workflow when a tool fails to run. This can be verified through the following steps:

1. Add a line of code to the `web_search` tool to cause it to throw an exception during execution.
2. Compile it into a browser extension, and then run the prompt "Search Sam Altman's information and summarize it into markdown format for export".
3. Observe the logs in the Popup.
4. The expected behavior is that after several failed attempts to invoke the tool, Eko will call the `cancel_workflow` tool to cancel the workflow.

For exceptions other than tool invocations, testing has shown that the current implementation can achieve the quick failure described in the requirements.