### PR TITLE
feature: human tools

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -115,7 +115,7 @@ export default [
         tsconfig: './tsconfig.json',
         declaration: true,
         declarationDir: 'dist',
-        include: ['src/types/*', 'src/nodejs/**/*']
+        include: ['src/types/*', 'src/nodejs/**/*', 'src/universal_tools/**/*']
       })
     ]
   },
@@ -135,7 +135,7 @@ export default [
         tsconfig: './tsconfig.json',
         declaration: true,
         declarationDir: 'dist',
-        include: ['src/types/*', 'src/nodejs/**/*']
+        include: ['src/types/*', 'src/nodejs/**/*', 'src/universal_tools/**/*']
       }),
       replace({
         preventAssignment: true,

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -509,6 +509,8 @@ export class ActionImpl implements Action {
     2. Think step by step about what needs to be done
     3. Return the output of the subtask using the 'return_output' tool when you are done; prefer using the 'tool_use_id' parameter to refer to the output of a tool call over providing a long text as the value
     4. Use the context to store important information for later reference, but use it sparingly: most of the time, the output of the subtask should be sufficient for the next steps
+    5. If there are any unclear points during the task execution, please use the human-related tool to inquire with the user
+    6. If user intervention is required during the task execution, please use the human-related tool to transfer the operation rights to the user
     `;
   }
 

--- a/src/services/workflow/generator.ts
+++ b/src/services/workflow/generator.ts
@@ -97,6 +97,7 @@ export class WorkflowGenerator {
     const specialTools = [
       "cancel_workflow",
       "human_input_text",
+      "human_operate",
     ]
     for (const node of workflowData.nodes) {
       for (const tool of specialTools) {

--- a/src/services/workflow/generator.ts
+++ b/src/services/workflow/generator.ts
@@ -96,6 +96,7 @@ export class WorkflowGenerator {
     // Forcibly add special tools
     const specialTools = [
       "cancel_workflow",
+      "human_input_text",
     ]
     for (const node of workflowData.nodes) {
       for (const tool of specialTools) {

--- a/src/services/workflow/templates.ts
+++ b/src/services/workflow/templates.ts
@@ -26,7 +26,8 @@ Generate a complete workflow that:
 2. Properly sequences tool usage based on dependencies
 3. Ensures each action has appropriate input/output schemas, and that the "tools" field in each action is populated with the sufficient subset of all available tools needed to complete the action
 4. Creates a clear, logical flow to accomplish the user's goal
-5. Includes detailed descriptions for each action, ensuring that the actions, when combined, is a complete solution to the user's problem`;
+5. Includes detailed descriptions for each action, ensuring that the actions, when combined, is a complete solution to the user's problem
+6. If the user's prompt is not clear enough, please first generate a SubTask and use human-related tools to ask the user for details`;
     },
 
     formatUserPrompt: (requirement: string) =>

--- a/src/types/tools.types.ts
+++ b/src/types/tools.types.ts
@@ -115,3 +115,12 @@ export interface ElementRect {
 export interface CancelWorkflowInput {
   reason: string;
 }
+
+export interface HumanInputTextInput {
+  question: string;
+}
+
+export interface HumanInputTextResult {
+  status: string;
+  answer: string;
+}

--- a/src/types/tools.types.ts
+++ b/src/types/tools.types.ts
@@ -124,3 +124,23 @@ export interface HumanInputTextResult {
   status: string;
   answer: string;
 }
+
+export interface HumanInputSingleChoiceInput {
+  question: string;
+  choices: string[];
+}
+
+export interface HumanInputSingleChoiceResult {
+  status: string;
+  answer: string;
+}
+
+export interface HumanInputMultipleChoiceInput {
+  question: string;
+  choices: string[];
+}
+
+export interface HumanInputMultipleChoiceResult {
+  status: string;
+  answer: string[];
+}

--- a/src/types/tools.types.ts
+++ b/src/types/tools.types.ts
@@ -144,3 +144,12 @@ export interface HumanInputMultipleChoiceResult {
   status: string;
   answer: string[];
 }
+
+export interface HumanOperateInput {
+  reason: string,
+}
+
+export interface HumanOperateResult {
+  status: string,
+  userOperation: string,
+}

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -52,5 +52,6 @@ export interface WorkflowCallback {
     onHumanInputText: (question: string) => Promise<string>;
     onHumanInputSingleChoice: (question: string, choices: string[]) => Promise<string>;
     onHumanInputMultipleChoice: (question: string, choices: string[]) => Promise<string[]>;
+    onHumanOperate: (reason: string) => Promise<string>;
   }
 };

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -49,5 +49,6 @@ export interface WorkflowCallback {
     afterWorkflow?: (workflow: Workflow, variables: Map<string, unknown>) => Promise<void>;
     onTabCreated?: (tabId: number) => Promise<void>;
     onLlmMessage?: (textContent: string) => Promise<void>;
+    onHumanInputText: (question: string) => Promise<string>;
   }
 };

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -50,5 +50,7 @@ export interface WorkflowCallback {
     onTabCreated?: (tabId: number) => Promise<void>;
     onLlmMessage?: (textContent: string) => Promise<void>;
     onHumanInputText: (question: string) => Promise<string>;
+    onHumanInputSingleChoice: (question: string, choices: string[]) => Promise<string>;
+    onHumanInputMultipleChoice: (question: string, choices: string[]) => Promise<string[]>;
   }
 };

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -50,8 +50,8 @@ export interface WorkflowCallback {
     onTabCreated?: (tabId: number) => Promise<void>;
     onLlmMessage?: (textContent: string) => Promise<void>;
     onHumanInputText: (question: string) => Promise<string>;
-    onHumanInputSingleChoice: (question: string, choices: string[]) => Promise<string>;
-    onHumanInputMultipleChoice: (question: string, choices: string[]) => Promise<string[]>;
+    onHumanInputSingleChoice?: (question: string, choices: string[]) => Promise<string>;
+    onHumanInputMultipleChoice?: (question: string, choices: string[]) => Promise<string[]>;
     onHumanOperate: (reason: string) => Promise<string>;
   }
 };

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -51,7 +51,7 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
   input_schema: InputSchema;
 
   constructor() {
-    this.name = 'human_input_text';
+    this.name = 'human_input_single_choice';
     this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE choice as an answer.';
     this.input_schema = {
       type: 'object',
@@ -94,7 +94,7 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
   input_schema: InputSchema;
 
   constructor() {
-    this.name = 'human_input_text';
+    this.name = 'human_input_multiple_choice';
     this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE or MANY choice as an answer.';
     this.input_schema = {
       type: 'object',

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -17,7 +17,7 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
 
   constructor() {
     this.name = 'human_input_text';
-    this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field. The user will provide you with a text as an answer.';
+    this.description = 'When you are unsure about the details of your next action, call me and ask the user for details in the "question" field. The user will provide you with a text as an answer.';
     this.input_schema = {
       type: 'object',
       properties: {
@@ -54,7 +54,7 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
 
   constructor() {
     this.name = 'human_input_single_choice';
-    this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE choice as an answer.';
+    this.description = 'When you are unsure about the details of your next action, call me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE choice as an answer.';
     this.input_schema = {
       type: 'object',
       properties: {
@@ -97,7 +97,7 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
 
   constructor() {
     this.name = 'human_input_multiple_choice';
-    this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE or MANY choice as an answer.';
+    this.description = 'When you are unsure about the details of your next action, call me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE or MORE choice as an answer.';
     this.input_schema = {
       type: 'object',
       properties: {
@@ -140,7 +140,7 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
 
   constructor() {
     this.name = 'human_operate';
-    this.description = 'When you encounter operations that require login, CAPTCHA verification, or other tasks that you cannot complete, please invoke this tool, transfer control to the user, and explain why.';
+    this.description = 'When you encounter operations that require login, CAPTCHA verification, or other tasks that you cannot complete, please call this tool, transfer control to the user, and explain why.';
     this.input_schema = {
       type: 'object',
       properties: {

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -1,4 +1,11 @@
-import { HumanInputTextInput, HumanInputTextResult } from '../types/tools.types';
+import { 
+  HumanInputTextInput,
+  HumanInputTextResult,
+  HumanInputSingleChoiceInput,
+  HumanInputSingleChoiceResult,
+  HumanInputMultipleChoiceInput,
+  HumanInputMultipleChoiceResult,
+} from '../types/tools.types';
 import { Tool, InputSchema, ExecutionContext } from '../types/action.types';
 
 export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextResult> {
@@ -30,10 +37,96 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
     let answer = await context.callback?.hooks.onHumanInputText(question);
     if (!answer) {
       console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: ""} as HumanInputTextResult;
+      return {status: "Error: Cannot get user's answer.", answer: ""};
     } else {
       console.log("answer: " + answer);
-      return {status: "OK", answer: answer} as HumanInputTextResult;
+      return {status: "OK", answer: answer};
+    }
+  }
+}
+
+export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput, HumanInputSingleChoiceResult> {
+  name: string;
+  description: string;
+  input_schema: InputSchema;
+
+  constructor() {
+    this.name = 'human_input_text';
+    this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE choice as an answer.';
+    this.input_schema = {
+      type: 'object',
+      properties: {
+        question: {
+          type: 'string',
+          description: 'Ask the user here.',
+        },
+        choices: {
+          type: 'array',
+          description: 'All of the choices.',
+        }
+      },
+      required: ['question', 'choices'],
+    };
+  }
+
+  async execute(context: ExecutionContext, params: HumanInputSingleChoiceInput): Promise<HumanInputSingleChoiceResult> {
+    if (typeof params !== 'object' || params === null || !params.question || !params.choices) {
+      throw new Error('Invalid parameters. Expected an object with a "question" and "choices" property.');
+    }
+    const question = params.question;
+    const choices = params.choices;
+    console.log("question: " + question);
+    console.log("choices: " + choices);
+    let answer = await context.callback?.hooks.onHumanInputSingleChoice(question, choices);
+    if (!answer) {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: ""};
+    } else {
+      console.log("answer: " + answer);
+      return {status: "OK", answer: answer};
+    }
+  }
+}
+
+export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceInput, HumanInputMultipleChoiceResult> {
+  name: string;
+  description: string;
+  input_schema: InputSchema;
+
+  constructor() {
+    this.name = 'human_input_text';
+    this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field with at least 2 choices. The user will provide you with ONE or MANY choice as an answer.';
+    this.input_schema = {
+      type: 'object',
+      properties: {
+        question: {
+          type: 'string',
+          description: 'Ask the user here.',
+        },
+        choices: {
+          type: 'array',
+          description: 'All of the choices.',
+        }
+      },
+      required: ['question', 'choices'],
+    };
+  }
+
+  async execute(context: ExecutionContext, params: HumanInputMultipleChoiceInput): Promise<HumanInputMultipleChoiceResult> {
+    if (typeof params !== 'object' || params === null || !params.question || !params.choices) {
+      throw new Error('Invalid parameters. Expected an object with a "question" and "choices" property.');
+    }
+    const question = params.question;
+    const choices = params.choices;
+    console.log("question: " + question);
+    console.log("choices: " + choices);
+    let answer = await context.callback?.hooks.onHumanInputMultipleChoice(question, choices);
+    if (!answer) {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: []};
+    } else {
+      console.log("answer: " + answer);
+      return {status: "OK", answer: answer};
     }
   }
 }

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -1,0 +1,39 @@
+import { HumanInputTextInput, HumanInputTextResult } from '../types/tools.types';
+import { Tool, InputSchema, ExecutionContext } from '../types/action.types';
+
+export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextResult> {
+  name: string;
+  description: string;
+  input_schema: InputSchema;
+
+  constructor() {
+    this.name = 'human_input_text';
+    this.description = 'When you are unsure about the details of your next action, invoke me and ask the user for details in the "question" field. The user will provide you with a text as an answer.';
+    this.input_schema = {
+      type: 'object',
+      properties: {
+        question: {
+          type: 'string',
+          description: 'Ask the user here.',
+        },
+      },
+      required: ['question'],
+    };
+  }
+
+  async execute(context: ExecutionContext, params: HumanInputTextInput): Promise<HumanInputTextResult> {
+    if (typeof params !== 'object' || params === null || !params.question) {
+      throw new Error('Invalid parameters. Expected an object with a "question" property.');
+    }
+    const question = params.question;
+    console.log("question: " + question);
+    let answer = await context.callback?.hooks.onHumanInputText(question);
+    if (!answer) {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: ""} as HumanInputTextResult;
+    } else {
+      console.log("answer: " + answer);
+      return {status: "OK", answer: answer} as HumanInputTextResult;
+    }
+  }
+}

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -79,7 +79,7 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
     const choices = params.choices;
     console.log("question: " + question);
     console.log("choices: " + choices);
-    let answer = await context.callback?.hooks.onHumanInputSingleChoice(question, choices);
+    let answer = await context.callback?.hooks.onHumanInputSingleChoice?.(question, choices);
     if (!answer) {
       console.error("Cannot get user's answer.");
       return {status: "Error: Cannot get user's answer.", answer: ""};
@@ -122,7 +122,7 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
     const choices = params.choices;
     console.log("question: " + question);
     console.log("choices: " + choices);
-    let answer = await context.callback?.hooks.onHumanInputMultipleChoice(question, choices);
+    let answer = await context.callback?.hooks.onHumanInputMultipleChoice?.(question, choices);
     if (!answer) {
       console.error("Cannot get user's answer.");
       return {status: "Error: Cannot get user's answer.", answer: []};

--- a/src/universal_tools/index.ts
+++ b/src/universal_tools/index.ts
@@ -1,9 +1,10 @@
 import { CancelWorkflow } from "./cancel_workflow";
-import { HumanInputText, HumanInputSingleChoice, HumanInputMultipleChoice } from "./human";
+import { HumanInputText, HumanInputSingleChoice, HumanInputMultipleChoice, HumanOperate } from "./human";
 
 export {
     CancelWorkflow,
     HumanInputText,
     HumanInputSingleChoice,
     HumanInputMultipleChoice,
+    HumanOperate,
 }

--- a/src/universal_tools/index.ts
+++ b/src/universal_tools/index.ts
@@ -1,5 +1,7 @@
 import { CancelWorkflow } from "./cancel_workflow";
+import { HumanInputText } from "./human";
 
 export {
     CancelWorkflow,
+    HumanInputText,
 }

--- a/src/universal_tools/index.ts
+++ b/src/universal_tools/index.ts
@@ -1,7 +1,9 @@
 import { CancelWorkflow } from "./cancel_workflow";
-import { HumanInputText } from "./human";
+import { HumanInputText, HumanInputSingleChoice, HumanInputMultipleChoice } from "./human";
 
 export {
     CancelWorkflow,
     HumanInputText,
+    HumanInputSingleChoice,
+    HumanInputMultipleChoice,
 }


### PR DESCRIPTION
这个 PR 增加了与用户交互的工具，它的原理是这样的：当大模型遇到一些他不能独自处理的问题（比如用户提供的 prompt 不够明确、网页需要登录等）时，Eko 会调用这些工具，来让用户和大模型互动，或者从 Eko 中获取对浏览器的控制权。

为了做到这一点，我提供了 4 个 tool：
1. `human_input_text`：大模型向用户询问一个问题，用户提供一个回答；
2. `human_input_single_choice`：大模型向用户询问一个问题，同时给出若干选项，用户从中选择一个；
3. `human_input_multiple_choice`: 大模型向用户询问一个问题，同时给出若干选项，用户从中选择一个或多个；
4. `human_operate`：大模型决定移交控制权，向用户提供一个理由，用户操作完毕后说明自己刚刚的操作。

为了让这些工具更好地发挥作用，我还做了其他修改：
1. 修改了两处 system prompt 来让模型知道 human tools 的意义；
2. 在每个 SubTask 中强制加入`human_input_text`和`human_operate`工具；
3. 同样地，在`WorkflowCallback`接口中新增两个必须提供的回调函数。

你可以通过以下步骤来测试`human_input_text`：
1. 在 [eko-browser-extension-template](https://github.com/FellouAI/eko-browser-extension-template) 的 `src/background/first_workflow.ts`文件中添加两个必需的回调函数：
```ts
      onHumanInputText: async (question: string) => {
        printLog("Question (Text): " + question);
        return "India";
      },
      onHumanOperate: async (reason: string) => {
        return "";
      }
```
2. 编译并加载浏览器插件；
3. 输入 prompt `Search the internet for my country's 2024 GDP growth rate in four quarters`；
4. 打开插件窗口和 Popup；
5. 期望行为是插件窗口打印日志 "Question (text): ..."，Popup 控制台打印日志 "answer: India"；

其他的 tool 也可以通过设计类似的用例来验证和测试。

---

This PR introduces tools for user interaction, and it works on the principle that when the large model encounters issues it cannot handle alone (such as unclear prompts provided by users, webpages requiring login, etc.), Eko will invoke these tools to enable interaction between the user and the large model, or to allow the user to take control of the browser from within Eko.

To achieve this, I have provided four tools:
1. `human_input_text`: The large model asks the user a question, and the user provides an answer.
2. `human_input_single_choice`: The large model asks the user a question and presents several options, from which the user selects one.
3. `human_input_multiple_choice`: The large model asks the user a question and presents several options, from which the user selects one or more.
4. `human_operate`: The large model decides to relinquish control and provides a reason to the user, who then describes their actions after completing them.

To enhance the functionality of these tools, I have made additional modifications:
1. Revised two system prompts to inform the model of the significance of human tools.
2. Mandatorily included the `human_input_text` and `human_operate` tools in each SubTask.
3. Similarly, added two mandatory callback functions in the `WorkflowCallback` interface.

You can test `human_input_text` through the following steps:
1. In the `src/background/first_workflow.ts` file of the [eko-browser-extension-template](https://github.com/FellouAI/eko-browser-extension-template), add the two required callback functions:
```ts
      onHumanInputText: async (question: string) => {
        printLog("Question (Text): " + question);
        return "India";
      },
      onHumanOperate: async (reason: string) => {
        return "";
      }
```
2. Compile and load the browser extension.
3. Enter the prompt `Search the internet for my country's 2024 GDP growth rate in four quarters`.
4. Open the extension window and Popup.
5. The expected behavior is for the extension window to print the log "Question (Text): ...", and the Popup console to print the log "answer: India".

Other tools can also be verified and tested by designing similar user scenarios.