### PR TITLE
Feature: deepseek provider & support for text-only model

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -48,7 +48,13 @@ export class Eko {
     } else {
       this.llmProvider = config as LLMProvider;
     }
-    Eko.tools.forEach((tool) => this.toolRegistry.registerTool(tool));
+
+    // filter tools
+    let tools = Array.from(Eko.tools.entries()).map(([key, tool]) => tool);
+    if (this.llmProvider.hasVisionCapacity()) {
+      tools = tools.filter(tool => !tool.need_vision);
+    }
+    tools.forEach(tool => this.toolRegistry.registerTool(tool));
   }
 
   public async generate(prompt: string, param?: EkoInvokeParam): Promise<Workflow> {

--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -11,8 +11,10 @@ import {
   OpenaiConfig,
   WorkflowCallback,
   NodeOutput,
+  DeepseekConfig,
 } from '../types';
 import { ToolRegistry } from './tool-registry';
+import { DeepseekProvider } from '@/services/llm/deepseek-provider';
 
 /**
  * Eko core
@@ -41,6 +43,13 @@ export class Eko {
           openaiConfig.apiKey,
           openaiConfig.modelName,
           openaiConfig.options
+        );
+      } else if (config.llm == 'deepseek') {
+        let deepseekConfig = config as DeepseekConfig;
+        this.llmProvider = new DeepseekProvider(
+          deepseekConfig.apiKey,
+          deepseekConfig.modelName,
+          deepseekConfig.options
         );
       } else {
         throw new Error('Unknown parameter: llm > ' + config['llm']);

--- a/src/extension/tools/browser_use.ts
+++ b/src/extension/tools/browser_use.ts
@@ -10,6 +10,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'browser_use';

--- a/src/extension/tools/element_click.ts
+++ b/src/extension/tools/element_click.ts
@@ -12,6 +12,7 @@ export class ElementClick implements Tool<TaskPrompt, any> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'element_click';

--- a/src/extension/tools/export_file.ts
+++ b/src/extension/tools/export_file.ts
@@ -10,6 +10,7 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'export_file';

--- a/src/extension/tools/extract_content.ts
+++ b/src/extension/tools/extract_content.ts
@@ -9,6 +9,7 @@ export class ExtractContent implements Tool<any, ExtractContentResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'extract_content';

--- a/src/extension/tools/find_element_position.ts
+++ b/src/extension/tools/find_element_position.ts
@@ -12,6 +12,7 @@ export class FindElementPosition implements Tool<TaskPrompt, ElementRect | null>
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'find_element_position';

--- a/src/extension/tools/get_all_tabs.ts
+++ b/src/extension/tools/get_all_tabs.ts
@@ -6,6 +6,7 @@ export class GetAllTabs implements Tool<any, BrowserTab[]> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'get_all_tabs';

--- a/src/extension/tools/open_url.ts
+++ b/src/extension/tools/open_url.ts
@@ -9,6 +9,7 @@ export class OpenUrl implements Tool<OpenUrlParam, OpenUrlResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'open_url';

--- a/src/extension/tools/request_login.ts
+++ b/src/extension/tools/request_login.ts
@@ -7,6 +7,7 @@ export class RequestLogin implements Tool<any, any> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'request_login';

--- a/src/extension/tools/screenshot.ts
+++ b/src/extension/tools/screenshot.ts
@@ -10,6 +10,7 @@ export class Screenshot implements Tool<any, ScreenshotResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'screenshot';

--- a/src/extension/tools/tab_management.ts
+++ b/src/extension/tools/tab_management.ts
@@ -21,6 +21,7 @@ export class TabManagement implements Tool<TabManagementParam, TabManagementResu
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'tab_management';

--- a/src/extension/tools/web_search.ts
+++ b/src/extension/tools/web_search.ts
@@ -1,6 +1,7 @@
 import { WebSearchParam, WebSearchResult } from '../../types/tools.types';
 import { Tool, InputSchema, ExecutionContext } from '../../types/action.types';
 import { MsgEvent, CountDownLatch, sleep, injectScript } from '../utils';
+import { DeepseekProvider } from '@/services/llm/deepseek-provider';
 
 /**
  * Web Search
@@ -44,7 +45,11 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
     let query = params.query;
     let maxResults = params.maxResults;
     if (!url) {
-      url = 'https://www.google.com';
+      // if (context.llmProvider instanceof DeepseekProvider) {
+      //   url = 'https://www.bing.com';
+      // } else {
+      //   url = 'https://www.google.com';
+      // }
     }
     let taskId = new Date().getTime() + '';
     let searchs = [{ url: url as string, keyword: query as string }];

--- a/src/extension/tools/web_search.ts
+++ b/src/extension/tools/web_search.ts
@@ -9,6 +9,7 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'web_search';

--- a/src/fellou/tools/computer_use.ts
+++ b/src/fellou/tools/computer_use.ts
@@ -9,6 +9,7 @@ export class ComputerUse implements Tool<ComputerUseParam, ComputerUseResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'computer_use';

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -33,6 +33,7 @@ class WriteContextTool implements Tool<any, any> {
     },
     required: ['key', 'value'],
   } as InputSchema;
+  need_vision: boolean = false;
 
   async execute(context: ExecutionContext, params: unknown): Promise<unknown> {
     const { key, value } = params as { key: string; value: string };
@@ -76,6 +77,7 @@ function createReturnTool(
       } as unknown,
       required: ['use_tool_result', 'value'],
     } as InputSchema,
+    need_vision: false,
 
     async execute(context: ExecutionContext, params: unknown): Promise<unknown> {
       context.variables.set(`__action_${actionName}_output`, params);

--- a/src/nodejs/tools/browser_use.ts
+++ b/src/nodejs/tools/browser_use.ts
@@ -10,6 +10,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   private browser: Browser | null = null;
   private browser_context: BrowserContext | null = null;

--- a/src/nodejs/tools/command_execute.ts
+++ b/src/nodejs/tools/command_execute.ts
@@ -13,6 +13,7 @@ export interface CommandExecuteParams {
 export class CommandExecute implements Tool<CommandExecuteParams, any> {
   name = 'command_execute';
   description = 'Execute a shell command with user confirmation';
+  need_vision: boolean = false;
   input_schema: InputSchema = {
     type: 'object',
     properties: {

--- a/src/nodejs/tools/file_read.ts
+++ b/src/nodejs/tools/file_read.ts
@@ -10,6 +10,7 @@ export interface FileReadParams {
 export class FileRead implements Tool<FileReadParams, any> {
   name = 'file_read';
   description = 'Read content from a file';
+  need_vision: boolean = false;
   input_schema: InputSchema = {
     type: 'object',
     properties: {

--- a/src/nodejs/tools/file_write.ts
+++ b/src/nodejs/tools/file_write.ts
@@ -14,6 +14,7 @@ export interface FileWriteParams {
 export class FileWrite implements Tool<FileWriteParams, any> {
   name = 'file_write';
   description = 'Write content to a file with user confirmation';
+  need_vision: boolean = false;
   input_schema: InputSchema = {
     type: 'object',
     properties: {

--- a/src/services/llm/claude-provider.ts
+++ b/src/services/llm/claude-provider.ts
@@ -60,6 +60,10 @@ export class ClaudeProvider implements LLMProvider {
     }
   }
 
+  public hasVisionCapacity(): boolean {
+    return true;
+  }
+  
   private processResponse(response: Anthropic.Message): LLMResponse {
     const toolCalls = response.content
       .filter((block): block is Anthropic.ToolUseBlock => block.type === 'tool_use')

--- a/src/services/llm/deepseek-provider.ts
+++ b/src/services/llm/deepseek-provider.ts
@@ -1,0 +1,361 @@
+import OpenAI, { ClientOptions } from 'openai';
+import {
+  LLMProvider,
+  LLMParameters,
+  LLMResponse,
+  Message,
+  LLMStreamHandler,
+  ToolCall,
+} from '../../types/llm.types';
+import {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionToolChoiceOption,
+} from 'openai/resources/chat';
+import {
+  ChatCompletionCreateParamsBase,
+  ChatCompletionCreateParamsStreaming,
+} from 'openai/resources/chat/completions';
+
+interface PartialToolUse {
+  id: string;
+  name: string;
+  accumulatedJson: string;
+}
+
+export class DeepseekProvider implements LLMProvider {
+  private client: OpenAI;
+  private defaultModel = 'deepseek-chat';
+
+  constructor(client: OpenAI, defaultModel?: string);
+  constructor(options: ClientOptions, defaultModel?: string);
+  constructor(apiKey: string, defaultModel?: string | null, options?: ClientOptions);
+
+  constructor(
+    param: string | ClientOptions | OpenAI,
+    defaultModel?: string | null,
+    options?: ClientOptions
+  ) {
+    if (defaultModel) {
+      this.defaultModel = defaultModel;
+    }
+    if (
+      typeof window !== 'undefined' &&
+      typeof document !== 'undefined' &&
+      (typeof param == 'string' || param.apiKey)
+    ) {
+      console.warn(`
+        ⚠️ Security Warning:
+        DO NOT use API Keys in browser/frontend code!
+        This will expose your credentials and may lead to unauthorized usage.
+        
+        Best Practices: Configure backend API proxy request through baseURL and request headers.
+
+        Please refer to the link: https://eko.fellou.ai/docs/getting-started/configuration#web-environment
+      `);
+    }
+    if (typeof param == 'string') {
+      this.client = new OpenAI({
+        apiKey: param,
+        dangerouslyAllowBrowser: true,
+        ...options,
+      });
+    } else if ((param as OpenAI).chat && (param as OpenAI).chat.completions) {
+      this.client = param as OpenAI;
+    } else {
+      let options = param as ClientOptions;
+      options.dangerouslyAllowBrowser = true;
+      this.client = new OpenAI(options);
+    }
+  }
+
+  private buildParams(
+    messages: Message[],
+    params: LLMParameters,
+    stream: boolean
+  ): ChatCompletionCreateParamsBase {
+    let tools: Array<ChatCompletionTool> | undefined = undefined;
+    if (params.tools && params.tools.length > 0) {
+      tools = [];
+      for (let i = 0; i < params.tools.length; i++) {
+        let tool = params.tools[i];
+        tools.push({
+          type: 'function',
+          function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.input_schema,
+          },
+        });
+      }
+    }
+    let tool_choice: ChatCompletionToolChoiceOption | undefined = undefined;
+    if (params.toolChoice) {
+      if (params.toolChoice.type == 'auto') {
+        tool_choice = 'auto';
+      } else if (params.toolChoice.type == 'tool') {
+        if (params.toolChoice.name) {
+          tool_choice = {
+            type: 'function',
+            function: { name: params.toolChoice.name as string },
+          };
+        } else {
+          tool_choice = 'required';
+        }
+      }
+    }
+    let _messages: Array<ChatCompletionMessageParam> = [];
+    for (let i = 0; i < messages.length; i++) {
+      let message = messages[i];
+      if (message.role == 'assistant' && typeof message.content !== 'string') {
+        let _content = undefined;
+        let _tool_calls = undefined;
+        for (let j = 0; j < message.content.length; j++) {
+          let content = message.content[j] as any;
+          if (content.type == 'text') {
+            if (!_content) {
+              _content = [];
+            }
+            _content.push(content);
+          } else if (content.type == 'tool_use') {
+            if (!_tool_calls) {
+              _tool_calls = [];
+            }
+            _tool_calls.push({
+              id: content.id,
+              type: 'function',
+              function: {
+                name: content.name,
+                arguments:
+                  typeof content.input == 'string' ? content.input : JSON.stringify(content.input),
+              },
+            });
+          }
+        }
+        _messages.push({
+          role: 'assistant',
+          content: _content,
+          tool_calls: _tool_calls as any,
+        });
+      } else if (message.role == 'user' && typeof message.content !== 'string') {
+        for (let j = 0; j < message.content.length; j++) {
+          let content = message.content[j] as any;
+          if (content.type == 'text') {
+            _messages.push({
+              role: 'user',
+              content: content.text,
+            });
+          } else if (content.type == 'image') {
+            _messages.push({
+              role: 'user',
+              content: [
+                {
+                  type: 'image_url',
+                  image_url: {
+                    url: `data:${content.source.media_type};base64,${content.source.data}`,
+                  },
+                },
+              ],
+            });
+          } else if (content.type == 'tool_result') {
+            let _content = [];
+            if (content.content == 'string') {
+              _content.push({ type: 'text', text: content.content });
+            } else {
+              for (let k = 0; k < content.content.length; k++) {
+                let item = content.content[k];
+                if (item.type == 'text') {
+                  _content.push({ ...item });
+                } else if (item.type == 'image') {
+                  _content.push({
+                    type: 'image_url',
+                    image_url: {
+                      url: `data:${item.source.media_type};base64,${item.source.data}`,
+                    },
+                  });
+                }
+              }
+            }
+            let hasImage = _content.filter((s) => s.type == 'image_url').length > 0;
+            if (hasImage) {
+              // OpenAI does not support images returned by the tool.
+              _messages.push({
+                role: 'tool',
+                content: 'ok',
+                tool_call_id: content.tool_call_id || content.tool_use_id,
+              });
+              _messages.push({
+                role: 'user',
+                content: _content,
+              });
+            } else {
+              _messages.push({
+                role: 'tool',
+                content: JSON.stringify(_content),
+                tool_call_id: content.tool_call_id || content.tool_use_id,
+              });
+            }
+          }
+        }
+      } else {
+        _messages.push(message as any);
+      }
+    }
+    return {
+      stream: stream,
+      model: params.model || this.defaultModel,
+      max_tokens: params.maxTokens || 4096,
+      temperature: params.temperature,
+      messages: _messages,
+      tools: tools,
+      tool_choice: tool_choice,
+    };
+  }
+
+  async generateText(messages: Message[], params: LLMParameters): Promise<LLMResponse> {
+    const response = await this.client.chat.completions.create(
+      this.buildParams(messages, params, false) as ChatCompletionCreateParamsNonStreaming
+    );
+    let textContent: string | null = null;
+    let toolCalls: ToolCall[] = [];
+    let stop_reason: string | null = null;
+    for (let i = 0; i < response.choices.length; i++) {
+      let choice = response.choices[i];
+      let message = choice.message;
+      if (message.content) {
+        if (textContent == null) {
+          textContent = '';
+        }
+        textContent += message.content;
+      }
+      if (message.tool_calls) {
+        for (let j = 0; j < message.tool_calls.length; j++) {
+          let tool_call = message.tool_calls[j];
+          toolCalls.push({
+            id: tool_call.id,
+            name: tool_call.function.name,
+            input: JSON.parse(tool_call.function.arguments),
+          });
+        }
+      }
+      if (choice.finish_reason) {
+        stop_reason = choice.finish_reason;
+      }
+    }
+
+    let content: unknown[] = [];
+    if (textContent) {
+      content.push({
+        type: 'text',
+        text: textContent,
+      });
+    }
+    if (toolCalls && toolCalls.length > 0) {
+      for (let i = 0; i < toolCalls.length; i++) {
+        let toolCall = toolCalls[i];
+        content.push({
+          type: 'tool_use',
+          id: toolCall.id,
+          name: toolCall.name,
+          input: toolCall.input,
+        });
+      }
+    }
+    return {
+      textContent,
+      content,
+      toolCalls,
+      stop_reason,
+    };
+  }
+
+  async generateStream(
+    messages: Message[],
+    params: LLMParameters,
+    handler: LLMStreamHandler
+  ): Promise<void> {
+    const stream = await this.client.chat.completions.create(
+      this.buildParams(messages, params, true) as ChatCompletionCreateParamsStreaming
+    );
+    handler.onStart?.();
+
+    let textContent: string | null = null;
+    let toolCalls: ToolCall[] = [];
+    let stop_reason: string | null = null;
+    let currentToolUse: PartialToolUse | null = null;
+
+    try {
+      for await (const chunk of stream) {
+        for (let i = 0; i < chunk.choices.length; i++) {
+          let choice = chunk.choices[i];
+          if (choice.delta) {
+            if (choice.delta.content) {
+              if (textContent == null) {
+                textContent = '';
+              }
+              textContent += choice.delta.content;
+              handler.onContent?.(choice.delta.content);
+            } else if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
+              let tool_calls = choice.delta.tool_calls[0];
+              if (!currentToolUse) {
+                currentToolUse = {
+                  id: tool_calls.id || '',
+                  name: tool_calls.function?.name || '',
+                  accumulatedJson: tool_calls.function?.arguments || '',
+                };
+              } else {
+                if (tool_calls.id) {
+                  currentToolUse.id = tool_calls.id;
+                }
+                if (tool_calls.function?.name) {
+                  currentToolUse.name = tool_calls.function?.name;
+                }
+                currentToolUse.accumulatedJson += tool_calls.function?.arguments || '';
+              }
+            }
+          }
+          if (choice.finish_reason) {
+            stop_reason = choice.finish_reason;
+            if (currentToolUse) {
+              const toolCall: ToolCall = {
+                id: currentToolUse.id,
+                name: currentToolUse.name,
+                input: JSON.parse(currentToolUse.accumulatedJson),
+              };
+              toolCalls.push(toolCall);
+              handler.onToolUse?.(toolCall);
+              currentToolUse = null;
+            }
+          }
+        }
+      }
+      let content: unknown[] = [];
+      if (textContent) {
+        content.push({
+          type: 'text',
+          text: textContent,
+        });
+      }
+      if (toolCalls && toolCalls.length > 0) {
+        for (let i = 0; i < toolCalls.length; i++) {
+          let toolCall = toolCalls[i];
+          content.push({
+            type: 'tool_use',
+            id: toolCall.id,
+            name: toolCall.name,
+            input: toolCall.input,
+          });
+        }
+      }
+      handler.onComplete?.({
+        textContent: textContent,
+        content: content,
+        toolCalls: toolCalls,
+        stop_reason: stop_reason,
+      });
+    } catch (error) {
+      handler.onError?.(error as Error);
+    }
+  }
+}

--- a/src/services/llm/deepseek-provider.ts
+++ b/src/services/llm/deepseek-provider.ts
@@ -70,6 +70,10 @@ export class DeepseekProvider implements LLMProvider {
     }
   }
 
+  public hasVisionCapacity(): boolean {
+    return false;
+  }
+  
   private buildParams(
     messages: Message[],
     params: LLMParameters,

--- a/src/services/llm/openai-provider.ts
+++ b/src/services/llm/openai-provider.ts
@@ -70,6 +70,10 @@ export class OpenaiProvider implements LLMProvider {
     }
   }
 
+  public hasVisionCapacity(): boolean {
+    return true;
+  }
+  
   private buildParams(
     messages: Message[],
     params: LLMParameters,

--- a/src/types/action.types.ts
+++ b/src/types/action.types.ts
@@ -7,6 +7,7 @@ export interface Tool<T, R> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean;
   execute: (context: ExecutionContext, params: T) => Promise<R>;
   destroy?: (context: ExecutionContext) => void;
 }

--- a/src/types/eko.types.ts
+++ b/src/types/eko.types.ts
@@ -17,9 +17,16 @@ export interface OpenaiConfig {
   options?: OpenAiClientOptions;
 }
 
+export interface DeepseekConfig {
+  llm: 'deepseek';
+  apiKey: string;
+  modelName?: string;
+  options?: OpenAiClientOptions;
+}
+
 export type ClaudeApiKey = string;
 
-export type EkoConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | LLMProvider;
+export type EkoConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | DeepseekConfig | LLMProvider;
 
 export interface EkoInvokeParam {
   tools?: Array<string> | Array<Tool<any, any>>;

--- a/src/types/llm.types.ts
+++ b/src/types/llm.types.ts
@@ -50,6 +50,7 @@ export interface LLMStreamHandler {
 }
 
 export interface LLMProvider {
+  hasVisionCapacity(): boolean;
   generateText(messages: Message[], params: LLMParameters): Promise<LLMResponse>;
   generateStream(messages: Message[], params: LLMParameters, handler: LLMStreamHandler): Promise<void>;
 }

--- a/src/universal_tools/cancel_workflow.ts
+++ b/src/universal_tools/cancel_workflow.ts
@@ -5,6 +5,7 @@ export class CancelWorkflow implements Tool<CancelWorkflowInput, void> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'cancel_workflow';

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -14,6 +14,7 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'human_input_text';
@@ -51,6 +52,7 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'human_input_single_choice';
@@ -94,6 +96,7 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'human_input_multiple_choice';
@@ -137,6 +140,7 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'human_operate';

--- a/src/universal_tools/summary_workflow.ts
+++ b/src/universal_tools/summary_workflow.ts
@@ -5,6 +5,7 @@ export class SummaryWorkflow implements Tool<SummaryWorkflowInput, void> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'summary_workflow';

--- a/src/web/tools/browser_use.ts
+++ b/src/web/tools/browser_use.ts
@@ -10,6 +10,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'browser_use';

--- a/src/web/tools/element_click.ts
+++ b/src/web/tools/element_click.ts
@@ -11,6 +11,7 @@ export class ElementClick implements Tool<TaskPrompt, any> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'element_click';

--- a/src/web/tools/export_file.ts
+++ b/src/web/tools/export_file.ts
@@ -9,6 +9,7 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'export_file';

--- a/src/web/tools/extract_content.ts
+++ b/src/web/tools/extract_content.ts
@@ -8,6 +8,7 @@ export class ExtractContent implements Tool<any, string> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = false;
 
   constructor() {
     this.name = 'extract_content';

--- a/src/web/tools/find_element_position.ts
+++ b/src/web/tools/find_element_position.ts
@@ -11,6 +11,7 @@ export class FindElementPosition implements Tool<TaskPrompt, ElementRect | null>
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'find_element_position';

--- a/src/web/tools/screenshot.ts
+++ b/src/web/tools/screenshot.ts
@@ -9,6 +9,7 @@ export class Screenshot implements Tool<any, ScreenshotResult> {
   name: string;
   description: string;
   input_schema: InputSchema;
+  need_vision: boolean = true;
 
   constructor() {
     this.name = 'screenshot';

--- a/test/integration/deepseek-provider.test.ts
+++ b/test/integration/deepseek-provider.test.ts
@@ -1,0 +1,201 @@
+import { DeepseekProvider } from '@/services/llm/deepseek-provider';
+import { OpenaiProvider } from '../../src/services/llm/openai-provider';
+import { LLMParameters, LLMStreamHandler, Message } from '../../src/types/llm.types';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_BASE_URL = "https://api.deepseek.com";
+if (!OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY environment variable is required for integration tests');
+}
+
+// Only run these tests if explicitly enabled
+const ENABLE_INTEGRATION_TESTS = process.env.ENABLE_INTEGRATION_TESTS === 'true';
+const describeIntegration = ENABLE_INTEGRATION_TESTS ? describe : describe.skip;
+
+// Default model for all tests
+const DEFAULT_MODEL = 'deepseek-chat';
+
+describeIntegration('OpenaiProvider Integration', () => {
+  let provider: DeepseekProvider;
+
+  beforeAll(() => {
+    provider = new DeepseekProvider(OPENAI_API_KEY, DEFAULT_MODEL, {
+      baseURL: OPENAI_BASE_URL,
+    });
+  });
+
+  describe('generateText', () => {
+    const params: LLMParameters = {
+      temperature: 0.7,
+      maxTokens: 1000,
+    };
+    const toolParams: LLMParameters = {
+      ...params,
+      tools: [
+        {
+          name: 'calculate',
+          description: 'Performs a calculation and returns the result',
+          input_schema: {
+            type: 'object',
+            properties: {
+              expression: {
+                type: 'string',
+                description: 'The mathematical expression to calculate',
+              },
+            },
+            required: ['expression'],
+          },
+        },
+      ],
+      toolChoice: { type: 'auto' },
+    };
+
+    test('should generate simple text response', async () => {
+      const messages: Message[] = [
+        {
+          role: 'user',
+          content: 'What is 2+2? Please respond with just the number.',
+        },
+      ];
+
+      const result = await provider.generateText(messages, params);
+      expect(result.textContent).toBe('4');
+      expect(result.toolCalls).toHaveLength(0);
+      expect(result.stop_reason).toBe('stop');
+    }, 30000);
+
+    test('should use tools when provided', async () => {
+      const messages: Message[] = [
+        {
+          role: 'user',
+          content: 'What is 234 * 456?',
+        },
+      ];
+
+      const result = await provider.generateText(messages, toolParams);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe('calculate');
+      expect(result.toolCalls[0].input).toHaveProperty('expression');
+      expect(result.stop_reason).toBe('tool_calls');
+    }, 30000);
+
+    it('should handle multi-turn conversation', async () => {
+      const user_message: Message = {
+        role: 'user',
+        content: 'What is 234 * 456?',
+      };
+      const messages_1: Message[] = [user_message];
+      const result_1 = await provider.generateText(messages_1, toolParams);
+      const tool_use_id = result_1.toolCalls[0].id;
+      const messages_2: Message[] = [
+        user_message,
+        {
+          role: 'assistant',
+          content: result_1.content,
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: tool_use_id,
+              content: [{ type: 'text', text: '106704' }],
+            },
+          ],
+        },
+      ];
+
+      const result = await provider.generateText(messages_2, toolParams);
+      expect(result.textContent).toMatch(/106,?704/);
+      expect(result.stop_reason).toBe('stop');
+    }, 30000);
+  });
+
+  describe('generateStream', () => {
+    it('should stream text content', async () => {
+      const accumulated: string[] = [];
+      let isStarted = false;
+      let isCompleted = false;
+
+      const handler: LLMStreamHandler = {
+        onStart: () => {
+          isStarted = true;
+        },
+        onContent: (content) => {
+          accumulated.push(content);
+        },
+        onComplete: () => {
+          isCompleted = true;
+        },
+        onError: (error) => {
+          throw error;
+        },
+      };
+
+      const messages: Message[] = [
+        {
+          role: 'user',
+          content: 'Count from 1 to 3, with each number on a new line (\n).',
+        },
+      ];
+
+      await provider.generateStream(
+        messages,
+        {
+          temperature: 0,
+          maxTokens: 100,
+        },
+        handler
+      );
+
+      expect(isStarted).toBe(true);
+      expect(isCompleted).toBe(true);
+      expect(accumulated.join('')).toMatch(/1\s+2\s+3\s?/);
+    }, 30000);
+
+    it('should stream tool use', async () => {
+      const toolCalls: any[] = [];
+      const handler: LLMStreamHandler = {
+        onToolUse: (toolCall) => {
+          toolCalls.push(toolCall);
+        },
+      };
+
+      const messages: Message[] = [
+        {
+          role: 'user',
+          content: 'What is 123 + 456?',
+        },
+      ];
+
+      await provider.generateStream(
+        messages,
+        {
+          temperature: 0,
+          tools: [
+            {
+              name: 'calculate',
+              description: 'Performs a calculation',
+              input_schema: {
+                type: 'object',
+                properties: {
+                  expression: { type: 'string' },
+                },
+                required: ['expression'],
+              },
+            },
+          ],
+          toolChoice: { type: 'auto' },
+        },
+        handler
+      );
+
+      expect(toolCalls).toHaveLength(1);
+      expect(toolCalls[0].name).toBe('calculate');
+      expect(toolCalls[0].input).toHaveProperty('expression');
+    }, 30000);
+  });
+});


### PR DESCRIPTION
这个 PR 主要添加了 DeepSeek 的 LLMProvider 以及对纯文本大模型的支持。这个 PR 做了以下修改：
1. 新增了 `DeepseekProvider` 以及对应的集成测试；
2. 对所有 `Tool` 新增了 `need_vision` 字段，当这个 `Tool` **可能**会需要大模型的视觉能力时该字段为 `true`，否则为`false`；
3. 对所有 `LLMProvider` 新增了 `hasVisionCapacity()` 方法，当这个 `LLMProvider` 有视觉能力时该方法返回 `true`，否则为 `false`；
4. 在 `Eko` 类的构造函数中，根据 `llmProvider.hasVisionCapacity()` 过滤可能使用的 tools。

对于第 1 条修改，你可以通过运行对应的集成测试来验证，具体命令如下：
```bash
export ENABLE_INTEGRATION_TESTS=1
export OPENAI_API_KEY=<your_deepseek_api_key>
npx jest deepseek-provider
```

对于其他修改，我目前暂时无法验证，一种可能的解决方法是在 https://github.com/FellouAI/eko-browser-extension-template 中添加对 `DeepseekProvider` 的支持后再来验证。

---

This PR mainly adds the LLMProvider for DeepSeek and support for plain text large models. The following modifications have been made in this PR:

1. Added `DeepseekProvider` and the corresponding integration tests;
2. Added a `need_vision` field to all `Tool` subclasses. This field is set to `true` if the `Tool` **may** require the vision capabilities of a large model, and `false` otherwise;
3. Added an `hasVisionCapacity()` method to all `LLMProvider` subclasses. This method returns `true` if the `LLMProvider` has vision capabilities, and `false` otherwise;
4. In the constructor of the `Eko` class, filtered the potential tools to use based on `llmProvider.hasVisionCapacity()`.

For the first modification, you can verify it by running the corresponding integration tests. The specific commands are as follows:
```bash
export ENABLE_INTEGRATION_TESTS=1
export OPENAI_API_KEY=<your_deepseek_api_key>
npx jest deepseek-provider
```

For the other modifications, I am currently unable to verify them. One possible solution is to add support for `DeepseekProvider` in the [https://github.com/FellouAI/eko-browser-extension-template](https://github.com/FellouAI/eko-browser-extension-template) repository before verification.