### PR TITLE
fix: no valid tab when export file

### DIFF
--- a/src/extension/tools/export_file.ts
+++ b/src/extension/tools/export_file.ts
@@ -74,8 +74,8 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
     } else {
       filename = params.filename;
     }
-    let tabId = await getTabId(context);
     try {
+      let tabId = await getTabId(context);
       await chrome.scripting.executeScript({
         target: { tabId: tabId as number },
         func: exportFile,
@@ -84,7 +84,7 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
     } catch (e) {
       let tab = await open_new_tab('https://www.google.com', true);
       context.callback?.hooks?.onTabCreated?.(tab.id as number);
-      tabId = tab.id as number;
+      let tabId = tab.id as number;
       await chrome.scripting.executeScript({
         target: { tabId: tabId as number },
         func: exportFile,


### PR DESCRIPTION
这个pr修复了使用浏览器插件导出文件时的错误：如果焦点窗口不在浏览器页面上，`getTabId` 会抛出错误，导致导出失败。  
为此，已将 `getTabId` 移入try-catch中，以确保在无法获取浏览器页面时，自动打开一个新页面以完成文件导出。

检验方法：编译并加载浏览器插件，运行含有**导出文件**指示的prompt。
期望行为是如果焦点窗口不在浏览器界面上，插件应自动打开一个新页面并顺利完成文件导出。

----

Fixed an issue with file export using the browser extension: If the focused window is not on the browser page, `getTabId` would throw an error, causing the export to fail.  
To address this, `getTabId` has been moved into a try-catch block to ensure that if the browser page cannot be found, a new page will be opened to complete the file export.

Testing Method:
Compile and load the browser extension. Enter a prompt that includes **file export** and execute it.

Expected Behavior:
If the focused window is not on the browser interface, the extension should automatically open a new page and successfully complete the file export.


