### PR TITLE
fix: may missing fields when calling `logError`

### DIFF
--- a/src/utils/execution-logger.ts
+++ b/src/utils/execution-logger.ts
@@ -126,9 +126,15 @@ export class ExecutionLogger {
    * Logs an error that occurred during execution
    */
   logError(error: Error, context?: ExecutionContext) {
-    this.log('error', `Error occurred: ${error.message}`, context);
-    if (error.stack) {
-      this.log('debug', `Stack trace: ${error.stack}`);
+    console.error(error);
+    try {
+      this.log('error', `Error occurred: ${error.message}`, context);
+      if (error.stack) {
+        this.log('debug', `Stack trace: ${error.stack}`);
+      }
+    } catch (error) {
+      console.error("An error occurs when trying to log another error:");
+      console.error(error);
     }
   }
 


### PR DESCRIPTION
这个 PR 修复了 `logError()` 方法中一个潜在的问题：参数`error`可能无法读取`message`字段，进而导致错误无法被记录下来。在实际使用过程中已经多次触发这个错误（需要补充日志）。

对此我的修复方法是给这个逻辑套上 try-catch，尝试捕获并记录这个错误，同时在方法的入口就在控制台打印这个错误，以免因为这个方法的错误实现导致其他错误无法被记录下来。

---

This PR fixes a potential issue in the `logError()` method: the parameter `error` may not be able to read the `message` field, which could subsequently prevent the error from being logged. This error has been triggered multiple times in actual usage (additional logging is needed).

My fix for this is to encapsulate this logic within a try-catch block to attempt to catch and log this error. At the same time, I will print the error to the console at the entrance of the method to prevent other errors from not being logged due to the faulty implementation of this method.