### PR TITLE
Feature: working window ID

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -79,7 +79,7 @@ export class Eko {
       }
     }
     const generator = new WorkflowGenerator(this.llmProvider, toolRegistry);
-    const workflow = await generator.generateWorkflow(prompt);
+    const workflow = await generator.generateWorkflow(prompt, this.ekoConfig);
     this.workflowGeneratorMap.set(workflow, generator);
     return workflow;
   }
@@ -114,7 +114,7 @@ export class Eko {
 
   public async modify(workflow: Workflow, prompt: string): Promise<Workflow> {
     const generator = this.workflowGeneratorMap.get(workflow) as WorkflowGenerator;
-    workflow = await generator.modifyWorkflow(prompt);
+    workflow = await generator.modifyWorkflow(prompt, this.ekoConfig);
     this.workflowGeneratorMap.set(workflow, generator);
     return workflow;
   }

--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -2,6 +2,7 @@ import { WorkflowGenerator } from '../services/workflow/generator';
 import { ClaudeProvider } from '../services/llm/claude-provider';
 import { OpenaiProvider } from '../services/llm/openai-provider';
 import {
+  LLMConfig,
   EkoConfig,
   EkoInvokeParam,
   LLMProvider,
@@ -11,6 +12,7 @@ import {
   OpenaiConfig,
   WorkflowCallback,
   NodeOutput,
+  ExecutionContext,
 } from '../types';
 import { ToolRegistry } from './tool-registry';
 
@@ -21,33 +23,45 @@ export class Eko {
   public static tools: Map<string, Tool<any, any>> = new Map();
 
   private llmProvider: LLMProvider;
+  private ekoConfig: EkoConfig;
   private toolRegistry = new ToolRegistry();
   private workflowGeneratorMap = new Map<Workflow, WorkflowGenerator>();
 
-  constructor(config: EkoConfig) {
-    if (typeof config == 'string') {
-      this.llmProvider = new ClaudeProvider(config);
-    } else if ('llm' in config) {
-      if (config.llm == 'claude') {
-        let claudeConfig = config as ClaudeConfig;
+  constructor(llmConfig: LLMConfig, ekoConfig?: EkoConfig) {
+    if (typeof llmConfig == 'string') {
+      this.llmProvider = new ClaudeProvider(llmConfig);
+    } else if ('llm' in llmConfig) {
+      if (llmConfig.llm == 'claude') {
+        let claudeConfig = llmConfig as ClaudeConfig;
         this.llmProvider = new ClaudeProvider(
           claudeConfig.apiKey,
           claudeConfig.modelName,
           claudeConfig.options
         );
-      } else if (config.llm == 'openai') {
-        let openaiConfig = config as OpenaiConfig;
+      } else if (llmConfig.llm == 'openai') {
+        let openaiConfig = llmConfig as OpenaiConfig;
         this.llmProvider = new OpenaiProvider(
           openaiConfig.apiKey,
           openaiConfig.modelName,
           openaiConfig.options
         );
       } else {
-        throw new Error('Unknown parameter: llm > ' + config['llm']);
+        let msg: string = 'Unknown parameter: llm > ' + llmConfig['llm'];
+        console.error(msg)
+        throw new Error(msg);
       }
     } else {
-      this.llmProvider = config as LLMProvider;
+      this.llmProvider = llmConfig as LLMProvider;
     }
+
+    if (ekoConfig) {
+      this.ekoConfig = ekoConfig;
+    } else {
+      this.ekoConfig = {
+        workingWindowId: undefined,
+      };
+    }
+
     Eko.tools.forEach((tool) => this.toolRegistry.registerTool(tool));
   }
 
@@ -132,8 +146,9 @@ export class Eko {
     if (typeof tool === 'string') {
       tool = this.getTool(tool);
     }
-    let context = {
+    let context: ExecutionContext = {
       llmProvider: this.llmProvider,
+      ekoConfig: this.ekoConfig,
       variables: new Map<string, unknown>(),
       tools: new Map<string, Tool<any, any>>(),
       callback,

--- a/src/extension/tools/export_file.ts
+++ b/src/extension/tools/export_file.ts
@@ -82,7 +82,13 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
         args: [filename, type, params.content],
       });
     } catch (e) {
-      let tab = await open_new_tab('https://www.google.com', true);
+      let tab;
+      const url = 'https://www.google.com';
+      if (context.ekoConfig.workingWindowId) {
+        tab = await open_new_tab(url, false, context.ekoConfig.workingWindowId);
+      } else {
+        tab = await open_new_tab(url, true);
+      }
       context.callback?.hooks?.onTabCreated?.(tab.id as number);
       let tabId = tab.id as number;
       await chrome.scripting.executeScript({

--- a/src/models/workflow.ts
+++ b/src/models/workflow.ts
@@ -1,5 +1,6 @@
 import { ExecutionLogger, LogOptions } from "@/utils/execution-logger";
 import { Workflow, WorkflowNode, NodeInput, NodeOutput, ExecutionContext, LLMProvider, WorkflowCallback } from "../types";
+import { EkoConfig } from "../types/eko.types";
 
 export class WorkflowImpl implements Workflow {
   abort?: boolean;
@@ -9,6 +10,7 @@ export class WorkflowImpl implements Workflow {
   constructor(
     public id: string,
     public name: string,
+    private ekoConfig: EkoConfig,
     public description?: string,
     public nodes: WorkflowNode[] = [],
     public variables: Map<string, unknown> = new Map(),
@@ -65,6 +67,7 @@ export class WorkflowImpl implements Workflow {
         workflow: this,
         variables: this.variables,
         llmProvider: this.llmProvider as LLMProvider,
+        ekoConfig: this.ekoConfig,
         tools: new Map(node.action.tools.map(tool => [tool.name, tool])),
         callback,
         logger: this.logger,

--- a/src/services/parser/workflow-parser.ts
+++ b/src/services/parser/workflow-parser.ts
@@ -2,13 +2,14 @@ import { Workflow, WorkflowNode, NodeInput, NodeOutput } from '../../types/workf
 import { ValidationResult, ValidationError } from '../../types/parser.types';
 import { WorkflowImpl } from '../../models/workflow';
 import { ActionImpl } from '../../models/action';
+import { EkoConfig } from '@/types';
 
 export class WorkflowParser {
   /**
    * Parse JSON string into runtime Workflow object
    * @throws {Error} if JSON is invalid or schema validation fails
    */
-  static parse(json: string): Workflow {
+  static parse(json: string, ekoConfig: EkoConfig): Workflow {
     let parsed: any;
 
     try {
@@ -24,7 +25,7 @@ export class WorkflowParser {
       );
     }
 
-    return this.toRuntime(parsed);
+    return this.toRuntime(parsed, ekoConfig);
   }
 
   /**
@@ -154,11 +155,12 @@ export class WorkflowParser {
     };
   }
 
-  private static toRuntime(json: any): Workflow {
+  private static toRuntime(json: any, ekoConfig: EkoConfig): Workflow {
     const variables = new Map(Object.entries(json.variables || {}));
     const workflow = new WorkflowImpl(
       json.id,
       json.name,
+      ekoConfig,
       json.description,
       [],
       variables,

--- a/src/services/workflow/generator.ts
+++ b/src/services/workflow/generator.ts
@@ -5,6 +5,7 @@ import { ActionImpl } from '../../models/action';
 import { ToolRegistry } from '../../core/tool-registry';
 import { createWorkflowPrompts, createWorkflowGenerationTool } from './templates';
 import { v4 as uuidv4 } from 'uuid';
+import { EkoConfig } from '@/types';
 
 export class WorkflowGenerator {
   message_history: Message[] = [];
@@ -14,15 +15,15 @@ export class WorkflowGenerator {
     private toolRegistry: ToolRegistry
   ) {}
 
-  async generateWorkflow(prompt: string): Promise<Workflow> {
-    return this.doGenerateWorkflow(prompt, false);
+  async generateWorkflow(prompt: string, ekoConfig: EkoConfig): Promise<Workflow> {
+    return this.doGenerateWorkflow(prompt, false, ekoConfig);
   }
 
-  async modifyWorkflow(prompt: string): Promise<Workflow> {
-    return this.doGenerateWorkflow(prompt, true);
+  async modifyWorkflow(prompt: string, ekoConfig: EkoConfig): Promise<Workflow> {
+    return this.doGenerateWorkflow(prompt, true, ekoConfig);
   }
 
-  private async doGenerateWorkflow(prompt: string, modify: boolean): Promise<Workflow> {
+  private async doGenerateWorkflow(prompt: string, modify: boolean, ekoConfig: EkoConfig): Promise<Workflow> {
     // Create prompts with current set of tools
     const prompts = createWorkflowPrompts(this.toolRegistry.getToolDefinitions());
 
@@ -117,13 +118,14 @@ export class WorkflowGenerator {
     console.log(workflowData);
     console.log("Debug the workflow...Done")    
     
-    return this.createWorkflowFromData(workflowData);
+    return this.createWorkflowFromData(workflowData, ekoConfig);
   }
 
-  private createWorkflowFromData(data: any): Workflow {
+  private createWorkflowFromData(data: any, ekoConfig: EkoConfig): Workflow {
     const workflow = new WorkflowImpl(
       data.id,
       data.name,
+      ekoConfig,
       data.description || '',
       [],
       new Map(Object.entries(data.variables || {})),

--- a/src/types/action.types.ts
+++ b/src/types/action.types.ts
@@ -2,6 +2,7 @@ import { Workflow } from "./workflow.types";
 import { LLMProvider } from "./llm.types";
 import { NodeOutput, WorkflowCallback } from "./workflow.types";
 import { NodeInput } from "./workflow.types";
+import { EkoConfig } from "./eko.types";
 
 export interface Tool<T, R> {
   name: string;
@@ -31,6 +32,7 @@ export interface Property {
 
 export interface ExecutionContext {
   llmProvider: LLMProvider;
+  ekoConfig: EkoConfig;
   variables: Map<string, unknown>;
   workflow?: Workflow;
   tools?: Map<string, Tool<any, any>>;

--- a/src/types/eko.types.ts
+++ b/src/types/eko.types.ts
@@ -19,7 +19,11 @@ export interface OpenaiConfig {
 
 export type ClaudeApiKey = string;
 
-export type EkoConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | LLMProvider;
+export type LLMConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | LLMProvider;
+
+export interface EkoConfig {
+  workingWindowId?: number,
+}
 
 export interface EkoInvokeParam {
   tools?: Array<string> | Array<Tool<any, any>>;

--- a/src/types/llm.types.ts
+++ b/src/types/llm.types.ts
@@ -13,8 +13,6 @@ export interface ToolDefinition {
   };
 }
 
-export interface LLMConfig {}
-
 export interface ToolCall {
   id: string;
   name: string;

--- a/test/integration/workflow.execution.test.ts
+++ b/test/integration/workflow.execution.test.ts
@@ -122,7 +122,8 @@ describeIntegration('Minimal Workflow Integration', () => {
     // Create workflow
     const workflow = new WorkflowImpl(
       'calc-and-display',
-      'Calculate and Display Workflow'
+      'Calculate and Display Workflow',
+      { workingWindowId: undefined },
     );
 
     workflow.llmProvider = llmProvider;

--- a/test/unit/workflow.test.ts
+++ b/test/unit/workflow.test.ts
@@ -1,11 +1,15 @@
 import { WorkflowImpl } from '../../src/models/workflow';
-import { WorkflowNode, Action, Tool, ExecutionContext } from '../../src/types';
+import { WorkflowNode, Action, Tool, ExecutionContext, EkoConfig } from '../../src/types';
 
 describe('WorkflowImpl', () => {
   let workflow: WorkflowImpl;
 
   beforeEach(() => {
-    workflow = new WorkflowImpl('test-id', 'Test Workflow');
+    workflow = new WorkflowImpl(
+      'test-id',
+      'Test Workflow',
+      { workingWindowId: undefined } as EkoConfig,
+    );
   });
 
   const createMockNode = (id: string, dependencies: string[] = []): WorkflowNode => ({


### PR DESCRIPTION
这个 PR 新增了 `workingWindowId` 作为 Eko 工作流执行时的环境。这个 PR 做了以下修改：
1. 把`EkoConfig`重构为`LLMConfig`;
2. 新增`EkoConfig`接口，包含一个`workingWindowId?: number`作为属性；
3. 在`ExecutionContext`接口新增一个`ekoConfig`属性；
4. 在`Eko`类的构造函数、工作流的生成和修改的方法等必要的地方新增了`ekoConfig`参数；
5. 修改了`web_search`和`export_file`在打开新窗口时的逻辑：如果`context.ekoConfig.workingWindowId`存在值时不打开新窗口，而是在指定的窗口执行动作；否则和往常一样执行。

你可以通过将`workingWindowId`设置为已经打开的浏览器窗口的 ID 来验证这个 PR，期望行为是`web_search`和`export_file`工具将不会打开新窗口。

---

This PR adds `workingWindowId` as an environment variable for Eko workflow execution. The following changes have been made in this PR:

1. Refactored `EkoConfig` to `LLMConfig`;
2. Added a new `EkoConfig` interface, which includes a property `workingWindowId?: number`;
3. Added an `ekoConfig` property to the `ExecutionContext` interface;
4. Added `ekoConfig` parameters in necessary places such as the constructor of the `Eko` class, workflow creation and modification methods, etc.;
5. Modified the logic for `web_search` and `export_file` when opening new windows: if `context.ekoConfig.workingWindowId` has a value, instead of opening a new window, the action will be executed in the specified window; otherwise, it will behave as usual.

To verify this PR, you can set the `workingWindowId` to the ID of an already open browser window. The expected behavior is that the `web_search` and `export_file` tools will not open a new window.