### PR TITLE
Fix: human tools empty answer

### DIFF
--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -38,11 +38,17 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
     console.log("question: " + question);
     let onHumanInputText = context.callback?.hooks.onHumanInputText;
     if (onHumanInputText) {
-      let answer = await onHumanInputText(question);
+      let answer;
+      try {
+        answer = await onHumanInputText(question);
+      } catch (e) {
+        console.error(e);
+        return {status: "Error: Cannot get user's answer.", answer: ""};
+      }
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
     } else {
-      console.error("Cannot get user's answer.");
+      console.error("`onHumanInputText` not implemented");
       return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
@@ -82,11 +88,17 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
     console.log("choices: " + choices);
     let onHumanInputSingleChoice = context.callback?.hooks.onHumanInputSingleChoice;
     if (onHumanInputSingleChoice) {
-      let answer = await onHumanInputSingleChoice(question, choices);
+      let answer;
+      try {
+        answer = await onHumanInputSingleChoice(question, choices);
+      } catch (e) {
+        console.error(e);
+        return {status: "Error: Cannot get user's answer.", answer: ""};
+      }
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
     } else {
-      console.error("Cannot get user's answer.");
+      console.error("`onHumanInputSingleChoice` not implemented");
       return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
@@ -126,7 +138,13 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
     console.log("choices: " + choices);
     let onHumanInputMultipleChoice = context.callback?.hooks.onHumanInputMultipleChoice;
     if (onHumanInputMultipleChoice) {
-      let answer = await onHumanInputMultipleChoice(question, choices)
+      let answer;
+      try {
+        answer = await onHumanInputMultipleChoice(question, choices)
+      } catch (e) {
+        console.error(e);
+        return {status: "`onHumanInputMultipleChoice` not implemented", answer: []};
+      }
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
     } else {
@@ -162,9 +180,15 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
     }
     const reason = params.reason;
     console.log("reason: " + reason);
-    let onHumanOperate = await context.callback?.hooks.onHumanOperate;
+    let onHumanOperate = context.callback?.hooks.onHumanOperate;
     if (onHumanOperate) {
-      let userOperation = await onHumanOperate(reason);
+      let userOperation;
+      try {
+        userOperation = await onHumanOperate(reason);
+      } catch (e) {
+        console.error(e);
+        return {status: "`onHumanOperate` not implemented", userOperation: ""};
+      }
       console.log("userOperation: " + userOperation);
       return {status: "OK", userOperation: userOperation};
     } else {

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -36,13 +36,14 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
     }
     const question = params.question;
     console.log("question: " + question);
-    let answer = await context.callback?.hooks.onHumanInputText?.(question);
-    if (!answer) {
-      console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: ""};
-    } else {
+    let onHumanInputText = context.callback?.hooks.onHumanInputText;
+    if (onHumanInputText) {
+      let answer = await onHumanInputText(question);
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
+    } else {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
 }
@@ -79,13 +80,14 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
     const choices = params.choices;
     console.log("question: " + question);
     console.log("choices: " + choices);
-    let answer = await context.callback?.hooks.onHumanInputSingleChoice?.(question, choices);
-    if (!answer) {
-      console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: ""};
-    } else {
+    let onHumanInputSingleChoice = context.callback?.hooks.onHumanInputSingleChoice;
+    if (onHumanInputSingleChoice) {
+      let answer = await onHumanInputSingleChoice(question, choices);
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
+    } else {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
 }
@@ -122,13 +124,14 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
     const choices = params.choices;
     console.log("question: " + question);
     console.log("choices: " + choices);
-    let answer = await context.callback?.hooks.onHumanInputMultipleChoice?.(question, choices);
-    if (!answer) {
-      console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: []};
-    } else {
+    let onHumanInputMultipleChoice = context.callback?.hooks.onHumanInputMultipleChoice;
+    if (onHumanInputMultipleChoice) {
+      let answer = await onHumanInputMultipleChoice(question, choices)
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
+    } else {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: []};
     }
   }
 }
@@ -159,13 +162,14 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
     }
     const reason = params.reason;
     console.log("reason: " + reason);
-    let userOperation = await context.callback?.hooks.onHumanOperate?.(reason);
-    if (!userOperation) {
-      console.error("Cannot get user's operation.");
-      return {status: "Error: Cannot get user's operation.", userOperation: ""};
-    } else {
+    let onHumanOperate = await context.callback?.hooks.onHumanOperate;
+    if (onHumanOperate) {
+      let userOperation = await onHumanOperate(reason);
       console.log("userOperation: " + userOperation);
       return {status: "OK", userOperation: userOperation};
+    } else {
+      console.error("Cannot get user's operation.");
+      return {status: "Error: Cannot get user's operation.", userOperation: ""};
     }
   }
 }


### PR DESCRIPTION
这个 PR 修复了以下问题：当 human tools 接收到用户提供的空回答（即`""`）时会认为没有实现相关的 callback，导致后续 Eko 执行失败。

你可以通过以下方式验证这个 PR：
1. 调用 human tools 时提供非空回答，期望行为是工具会正常返回用户的回答；
2. 调用 human tools 时故意提供空的回答，期望行为是工具 _不会_ 返回`status="Error: Cannot get user's answer."`的结果；
3. 不实现相关的 callback，再调用 human tools，期望行为是工具 _会_ 返回`status="Error: Cannot get user's answer."`的结果。

---

This PR fixes the following issue: When human tools receive a `""` response from the user, it incorrectly assumes that the relevant callback has not been implemented, leading to subsequent Eko execution failures.

You can verify this PR by following these steps:
1. Provide a non-empty response when calling human tools. The expected behavior is that the tool will normally return the user's response.
2. Deliberately provide an empty response when calling human tools. The expected behavior is that the tool will _not_ return a result with `status="Error: Cannot get user's answer."`
3. Do not implement the relevant callback and then call human tools. The expected behavior is that the tool will _return_ a result with `status="Error: Cannot get user's answer."`