### PR TITLE
Feature: filter human tools if hooks not exist

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -61,8 +61,35 @@ export class Eko {
         workingWindowId: undefined,
       };
     }
+    this.registerTools();
+  }
 
-    Eko.tools.forEach((tool) => this.toolRegistry.registerTool(tool));
+  private registerTools() {
+    let tools = Array.from(Eko.tools.entries()).map(([_key, tool]) => tool);
+
+    // filter human tools by callbacks
+    const callback = this.ekoConfig.callback;
+    if (callback) {
+      const hooks = callback.hooks;
+
+      // these tools could not work without corresponding hook
+      const tool2isHookExists: { [key: string]: boolean } = {
+        "human_input_text": Boolean(hooks.onHumanInputText),
+        "human_input_single_choice": Boolean(hooks.onHumanInputSingleChoice),
+        "human_input_multiple_choice": Boolean(hooks.onHumanInputMultipleChoice),
+        "human_operate": Boolean(hooks.onHumanOperate),
+      };
+      tools = tools.filter(tool => {
+        if (tool.name in tool2isHookExists) {
+          let isHookExists = tool2isHookExists[tool.name]
+          return isHookExists;
+        } else {
+          return true;
+        }
+      });
+    }
+    
+    tools.forEach(tool => this.toolRegistry.registerTool(tool));
   }
 
   public async generate(prompt: string, param?: EkoInvokeParam): Promise<Workflow> {
@@ -84,7 +111,7 @@ export class Eko {
     return workflow;
   }
 
-  public async execute(workflow: Workflow, callback?: WorkflowCallback): Promise<NodeOutput[]> {
+  public async execute(workflow: Workflow): Promise<NodeOutput[]> {
     // Inject LLM provider at workflow level
     workflow.llmProvider = this.llmProvider;
 
@@ -104,7 +131,7 @@ export class Eko {
       }
     }
 
-    return await workflow.execute(callback);
+    return await workflow.execute(this.ekoConfig.callback);
   }
 
   public async cancel(workflow: Workflow): Promise<void> {

--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -57,9 +57,8 @@ export class Eko {
     if (ekoConfig) {
       this.ekoConfig = ekoConfig;
     } else {
-      this.ekoConfig = {
-        workingWindowId: undefined,
-      };
+      console.warn("`ekoConfig` is missing when construct `Eko` instance, default to `{}`");
+      this.ekoConfig = {};
     }
     this.registerTools();
   }
@@ -87,6 +86,8 @@ export class Eko {
           return true;
         }
       });
+    } else {
+      console.warn("`ekoConfig.callback` is missing when construct `Eko` instance.")
     }
     
     tools.forEach(tool => this.toolRegistry.registerTool(tool));

--- a/src/types/eko.types.ts
+++ b/src/types/eko.types.ts
@@ -2,6 +2,7 @@ import { ClientOptions as OpenAiClientOptions } from 'openai';
 import { ClientOptions as ClaudeClientOption } from '@anthropic-ai/sdk';
 import { LLMProvider } from './llm.types';
 import { Tool } from './action.types';
+import { WorkflowCallback } from './workflow.types';
 
 export interface ClaudeConfig {
   llm: 'claude';
@@ -23,6 +24,7 @@ export type LLMConfig = ClaudeApiKey | ClaudeConfig | OpenaiConfig | LLMProvider
 
 export interface EkoConfig {
   workingWindowId?: number,
+  callback?: WorkflowCallback,
 }
 
 export interface EkoInvokeParam {

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -38,11 +38,17 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
     console.log("question: " + question);
     let onHumanInputText = context.callback?.hooks.onHumanInputText;
     if (onHumanInputText) {
-      let answer = await onHumanInputText(question);
+      let answer;
+      try {
+        answer = await onHumanInputText(question);
+      } catch (e) {
+        console.error(e);
+        return {status: "Error: Cannot get user's answer.", answer: ""};
+      }
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
     } else {
-      console.error("Cannot get user's answer.");
+      console.error("`onHumanInputText` not implemented");
       return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
@@ -82,11 +88,17 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
     console.log("choices: " + choices);
     let onHumanInputSingleChoice = context.callback?.hooks.onHumanInputSingleChoice;
     if (onHumanInputSingleChoice) {
-      let answer = await onHumanInputSingleChoice(question, choices);
+      let answer;
+      try {
+        answer = await onHumanInputSingleChoice(question, choices);
+      } catch (e) {
+        console.error(e);
+        return {status: "Error: Cannot get user's answer.", answer: ""};
+      }
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
     } else {
-      console.error("Cannot get user's answer.");
+      console.error("`onHumanInputSingleChoice` not implemented");
       return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
@@ -126,7 +138,13 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
     console.log("choices: " + choices);
     let onHumanInputMultipleChoice = context.callback?.hooks.onHumanInputMultipleChoice;
     if (onHumanInputMultipleChoice) {
-      let answer = await onHumanInputMultipleChoice(question, choices)
+      let answer;
+      try {
+        answer = await onHumanInputMultipleChoice(question, choices)
+      } catch (e) {
+        console.error(e);
+        return {status: "`onHumanInputMultipleChoice` not implemented", answer: []};
+      }
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
     } else {
@@ -162,9 +180,15 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
     }
     const reason = params.reason;
     console.log("reason: " + reason);
-    let onHumanOperate = await context.callback?.hooks.onHumanOperate;
+    let onHumanOperate = context.callback?.hooks.onHumanOperate;
     if (onHumanOperate) {
-      let userOperation = await onHumanOperate(reason);
+      let userOperation;
+      try {
+        userOperation = await onHumanOperate(reason);
+      } catch (e) {
+        console.error(e);
+        return {status: "`onHumanOperate` not implemented", userOperation: ""};
+      }
       console.log("userOperation: " + userOperation);
       return {status: "OK", userOperation: userOperation};
     } else {

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -36,13 +36,14 @@ export class HumanInputText implements Tool<HumanInputTextInput, HumanInputTextR
     }
     const question = params.question;
     console.log("question: " + question);
-    let answer = await context.callback?.hooks.onHumanInputText?.(question);
-    if (!answer) {
-      console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: ""};
-    } else {
+    let onHumanInputText = context.callback?.hooks.onHumanInputText;
+    if (onHumanInputText) {
+      let answer = await onHumanInputText(question);
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
+    } else {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
 }
@@ -79,13 +80,14 @@ export class HumanInputSingleChoice implements Tool<HumanInputSingleChoiceInput,
     const choices = params.choices;
     console.log("question: " + question);
     console.log("choices: " + choices);
-    let answer = await context.callback?.hooks.onHumanInputSingleChoice?.(question, choices);
-    if (!answer) {
-      console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: ""};
-    } else {
+    let onHumanInputSingleChoice = context.callback?.hooks.onHumanInputSingleChoice;
+    if (onHumanInputSingleChoice) {
+      let answer = await onHumanInputSingleChoice(question, choices);
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
+    } else {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: ""};
     }
   }
 }
@@ -122,13 +124,14 @@ export class HumanInputMultipleChoice implements Tool<HumanInputMultipleChoiceIn
     const choices = params.choices;
     console.log("question: " + question);
     console.log("choices: " + choices);
-    let answer = await context.callback?.hooks.onHumanInputMultipleChoice?.(question, choices);
-    if (!answer) {
-      console.error("Cannot get user's answer.");
-      return {status: "Error: Cannot get user's answer.", answer: []};
-    } else {
+    let onHumanInputMultipleChoice = context.callback?.hooks.onHumanInputMultipleChoice;
+    if (onHumanInputMultipleChoice) {
+      let answer = await onHumanInputMultipleChoice(question, choices)
       console.log("answer: " + answer);
       return {status: "OK", answer: answer};
+    } else {
+      console.error("Cannot get user's answer.");
+      return {status: "Error: Cannot get user's answer.", answer: []};
     }
   }
 }
@@ -159,13 +162,14 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
     }
     const reason = params.reason;
     console.log("reason: " + reason);
-    let userOperation = await context.callback?.hooks.onHumanOperate?.(reason);
-    if (!userOperation) {
-      console.error("Cannot get user's operation.");
-      return {status: "Error: Cannot get user's operation.", userOperation: ""};
-    } else {
+    let onHumanOperate = await context.callback?.hooks.onHumanOperate;
+    if (onHumanOperate) {
+      let userOperation = await onHumanOperate(reason);
       console.log("userOperation: " + userOperation);
       return {status: "OK", userOperation: userOperation};
+    } else {
+      console.error("Cannot get user's operation.");
+      return {status: "Error: Cannot get user's operation.", userOperation: ""};
     }
   }
 }


### PR DESCRIPTION
**这个 PR 修改了以下接口，请下游使用者注意：**
1. `Eko.constructor()`
2. `Eko.execute()`
3. `EkoConfig`

这个 PR 会在规划工作流时根据 hooks 是否存在过滤一部分用户相关工具（human tools）。具体来说这个 PR 做了以下修改：
1. 将`Eko.constructor()`中注册工具的逻辑抽象成`Eko.registerTools()`；
4. 注册工具时，如果工具是 human tools，则判断是否存在对应的 hook，若无则剔除该工具，其他情况下保留该工具；
5. 修改了`Eko.execute()`的签名，删除了`callback?: WorkflowCallback`参数；
6. 给`EkoConfig`接口新增了`callback?: WorkflowCallback`字段；
7. 新增了几处`console.warn`，当`ekoConfig`的部分或全部为空时会警告。

你可以通过以下方式来验证这个 PR：
1. 编写以下代码：
```typescript
// Initialize eko
let eko = new Eko(config as LLMConfig, { callback: your_callback });

// Generate a workflow from natural language description
const workflow = await eko.generate(prompt);

// Execute the workflow
await eko.execute(workflow);
```
2. 提供一部分 human tools 对应的 hook，期望行为是提供了 hook 的工具会在合适的时候加入工作流，没有提供 hook 的工具不会出现在工作流中。

---

**This PR modifies the following interfaces. Please note for downstream users**:

1. `Eko.constructor()`
2. `Eko.execute()`
3. `EkoConfig`

This PR filters out some human-related tools based on the presence of hooks when planning the workflow. Specifically, the following changes have been made in this PR:

1. Abstracted the logic for registering tools in `Eko.constructor()` into `Eko.registerTools()`.
4. When registering tools, if the tool is a human tool, it checks whether the corresponding hook exists. If not, the tool is removed; otherwise, it is retained.
5. Modified the signature of `Eko.execute()` by removing the `callback?: WorkflowCallback` parameter.
6. Added a new `callback?: WorkflowCallback` field to the `EkoConfig` interface.
7. Added several `console.warn` statements to warn when part or all of `ekoConfig` is empty.

You can verify this PR in the following way:

1. Write the following code:
```typescript
// Initialize eko
let eko = new Eko(config as LLMConfig, { callback: your_callback });

// Generate a workflow from natural language description
const workflow = await eko.generate(prompt);

// Execute the workflow
await eko.execute(workflow);
```
2. Provide some hooks corresponding to human tools. The expected behavior is that tools with provided hooks will be included in the workflow at the appropriate time, while tools without provided hooks will not appear in the workflow.