### PR TITLE
fix: add confirmations in `human_operate` description

### DIFF
--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -161,7 +161,7 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
 
   constructor() {
     this.name = 'human_operate';
-    this.description = 'When you encounter operations that require login, CAPTCHA verification, or other tasks that you cannot complete, please call this tool, transfer control to the user, and explain why.\n\nAsk the user for final confirmation before the final step of any task with external side effects. This includes submitting purchases, deletions, editing data, appointments, sending a message, managing accounts, moving files, etc. Do not confirm before adding items to a cart, or other intermediate steps.';
+    this.description = 'When you encounter operations necessitating login, CAPTCHA verification, or any other tasks beyond your reach, kindly invoke this tool, relinquish control to the user, and elucidate the reasons behind this action.\n\nBefore executing the final step of any task that entails external repercussions, such as submitting purchases, deleting entries, editing data, scheduling appointments, sending messages, managing accounts, moving files, and the like, seek the user\'s definitive confirmation.';
     this.input_schema = {
       type: 'object',
       properties: {

--- a/src/universal_tools/human.ts
+++ b/src/universal_tools/human.ts
@@ -161,7 +161,7 @@ export class HumanOperate implements Tool<HumanOperateInput, HumanOperateResult>
 
   constructor() {
     this.name = 'human_operate';
-    this.description = 'When you encounter operations that require login, CAPTCHA verification, or other tasks that you cannot complete, please call this tool, transfer control to the user, and explain why.';
+    this.description = 'When you encounter operations that require login, CAPTCHA verification, or other tasks that you cannot complete, please call this tool, transfer control to the user, and explain why.\n\nAsk the user for final confirmation before the final step of any task with external side effects. This includes submitting purchases, deletions, editing data, appointments, sending a message, managing accounts, moving files, etc. Do not confirm before adding items to a cart, or other intermediate steps.';
     this.input_schema = {
       type: 'object',
       properties: {


### PR DESCRIPTION
这个 PR 对`human_operate`工具的`description`字段补充了一些说明，强调它在做一些危险操作时需要询问用户意见。

---

This PR adds some text to the `description` field of the `human_operate` tool, emphasizing the need to ask for user consent when performing dangerous operations.