### PR TITLE
feat: add `WorkflowResult`

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -8,8 +8,8 @@ import {
   Tool,
   Workflow,
   WorkflowCallback,
-  NodeOutput,
   ExecutionContext,
+  WorkflowResult
 } from '../types';
 import { ToolRegistry } from './tool-registry';
 
@@ -86,7 +86,7 @@ export class Eko {
     return workflow;
   }
 
-  public async execute(workflow: Workflow): Promise<NodeOutput[]> {
+  public async execute(workflow: Workflow): Promise<WorkflowResult> {
     // Inject LLM provider at workflow level
     workflow.llmProvider = this.llmProvider;
 
@@ -106,7 +106,9 @@ export class Eko {
       }
     }
 
-    return await workflow.execute(this.ekoConfig.callback);
+    const result = await workflow.execute(this.ekoConfig.callback);
+    console.log(result);
+    return result;
   }
 
   public async cancel(workflow: Workflow): Promise<void> {

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -11,42 +11,7 @@ import {
   LLMResponse,
 } from '../types/llm.types';
 import { ExecutionLogger } from '@/utils/execution-logger';
-
-/**
- * Special tool that allows LLM to write values to context
- */
-class WriteContextTool implements Tool<any, any> {
-  name = 'write_context';
-  description =
-    'Write a value to the global workflow context. Use this to store important intermediate results, but only when a piece of information is essential for future reference but missing from the final output specification of the current action.';
-  input_schema = {
-    type: 'object',
-    properties: {
-      key: {
-        type: 'string',
-        description: 'The key to store the value under',
-      },
-      value: {
-        type: 'string',
-        description: 'The value to store (must be JSON stringified if object/array)',
-      },
-    },
-    required: ['key', 'value'],
-  } as InputSchema;
-
-  async execute(context: ExecutionContext, params: unknown): Promise<unknown> {
-    const { key, value } = params as { key: string; value: string };
-    try {
-      // Try to parse the value as JSON
-      const parsedValue = JSON.parse(value);
-      context.variables.set(key, parsedValue);
-    } catch {
-      // If parsing fails, store as string
-      context.variables.set(key, value);
-    }
-    return { success: true, key, value };
-  }
-}
+import { WriteContextTool } from '@/universal_tools/write_context';
 
 function createReturnTool(
   actionName: string,

--- a/src/services/workflow/generator.ts
+++ b/src/services/workflow/generator.ts
@@ -91,8 +91,26 @@ export class WorkflowGenerator {
 
     const workflowData = response.toolCalls[0].input.workflow as any;
 
-    
+    // debug
+    console.log("Debug the workflow...")
+    console.log({ ...workflowData});
 
+    // Add workflow summary subtask
+    (workflowData.nodes as any[]).push({
+      "id": "final",
+      "type": "action",
+      "dependencies": workflowData.nodes.map((node: { id: any; }) => node.id),
+      "action": {
+        "type": "prompt",
+        "name": "Summarize the workflow.",
+        "description": "Summarize briefly what this workflow has accomplished. Your summary should be based on user\'s original query.",
+        "tools": [
+          "summary_workflow"
+        ]
+      },
+    })
+    console.log("Debug the workflow...Done")    
+    
     // Validate all tools exist
     for (const node of workflowData.nodes) {
       if (!this.toolRegistry.hasTools(node.action.tools)) {
@@ -105,11 +123,6 @@ export class WorkflowGenerator {
       workflowData.id = uuidv4();
     }
 
-    // debug
-    console.log("Debug the workflow...")
-    console.log(workflowData);
-    console.log("Debug the workflow...Done")    
-    
     return this.createWorkflowFromData(workflowData, ekoConfig);
   }
 

--- a/src/services/workflow/templates.ts
+++ b/src/services/workflow/templates.ts
@@ -27,7 +27,7 @@ Generate a complete workflow that:
 3. Ensures each action has appropriate input/output schemas, and that the "tools" field in each action is populated with the sufficient subset of all available tools needed to complete the action
 4. Creates a clear, logical flow to accomplish the user's goal
 5. Includes detailed descriptions for each action, ensuring that the actions, when combined, is a complete solution to the user's problem
-6. You should always add a SubTask at the end of the workflow to summarize it, and this SubTask should always call the "summary_workflow" tool. It's dependencies should be all of the SubTasks`;
+6. Do not use 'summary_workflow' tool`;
     },
 
     formatUserPrompt: (requirement: string) =>

--- a/src/types/eko.types.ts
+++ b/src/types/eko.types.ts
@@ -30,3 +30,13 @@ export interface EkoConfig {
 export interface EkoInvokeParam {
   tools?: Array<string> | Array<Tool<any, any>>;
 }
+
+export interface WorkflowResult {
+  isSuccessful: boolean,
+  summary: string,
+  payload: WorkflowTranscript | WorkflowArtifact,
+}
+
+export type WorkflowTranscript = string
+
+export interface WorkflowArtifact {} // TODO

--- a/src/types/tools.types.ts
+++ b/src/types/tools.types.ts
@@ -155,5 +155,20 @@ export interface HumanOperateResult {
 }
 
 export interface SummaryWorkflowInput {
+  isSuccessful: boolean,
   summary: string,
+}
+
+export interface DocumentAgentToolInput {
+  type: string,
+  title: string,
+  background: string,
+  keypoints: string,
+  style?: string,
+  references?: any,
+}
+
+export interface DocumentAgentToolOutput {
+  status: string,
+  content: string,
 }

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -2,6 +2,7 @@ import { Action, ExecutionContext, Tool } from "./action.types";
 import { LLMProvider } from "./llm.types";
 import { ExecutionLogger } from "@/utils/execution-logger";
 import { ExportFileParam } from "./tools.types";
+import { WorkflowResult } from "./eko.types";
 
 export interface NodeOutput {
   name: string;
@@ -32,7 +33,7 @@ export interface Workflow {
   llmProvider?: LLMProvider;
 
   setLogger(logger: ExecutionLogger): void;
-  execute(callback?: WorkflowCallback): Promise<NodeOutput[]>;
+  execute(callback?: WorkflowCallback): Promise<WorkflowResult>;
   cancel(): Promise<void>;
   addNode(node: WorkflowNode): void;
   removeNode(nodeId: string): void;

--- a/src/universal_tools/document_agent.ts
+++ b/src/universal_tools/document_agent.ts
@@ -1,0 +1,65 @@
+import {
+  LLMParameters,
+  Tool,
+  InputSchema,
+  ExecutionContext,
+  DocumentAgentToolInput,
+  DocumentAgentToolOutput,
+  Message,
+} from '@/types';
+
+export class DocumentAgentTool implements Tool<DocumentAgentToolInput, DocumentAgentToolOutput> {
+  name: string;
+  description: string;
+  input_schema: InputSchema;
+
+  constructor() {
+    this.name = 'document_agent';
+    this.description = 'A document agent that can help you write document or long text, e.g. research report, email draft, summary.';
+    this.input_schema = {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of document to be created (e.g., 'report', 'presentation', 'article')."
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the document."
+        },
+        "background": {
+          "type": "string",
+          "description": "The background information or target for the document."
+        },
+        "keypoints": {
+          "type": "string",
+          "description": "A summary of the key points or main ideas to be included in the document."
+        },
+        "style": {
+          "type": "string",
+          "description": "The desired style or tone of the document (e.g., 'formal', 'casual', 'academic')."
+        },
+      },
+      "required": ["type", "title", "background", "keypoints"],
+    };
+  }
+
+  async execute(context: ExecutionContext, params: DocumentAgentToolInput): Promise<DocumentAgentToolOutput> {
+    params.references = context.variables;
+    const messages: Message[] = [
+      {
+        role: 'system',
+        content: 'You are an excellent writer, skilled at composing various types of copywriting and texts in different styles. You can draft documents based on the title, background, or reference materials provided by clients. Now, the client will provide you with a lot of information, including the type of copywriting, title, background, key points, style, and reference materials. Please write a document in Markdown format.',
+      },
+      {
+        role: 'user',
+        content: JSON.stringify(params),
+      },
+    ];
+    const llmParams: LLMParameters = { maxTokens: 8192 };
+    const response = await context.llmProvider.generateText(messages, llmParams);
+    const content = typeof response.content == 'string' ? response.content : (response.content as any[])[0].text;
+    context.variables.set("workflow_transcript", content);
+    return { status: "OK", content };
+  }
+}

--- a/src/universal_tools/index.ts
+++ b/src/universal_tools/index.ts
@@ -1,6 +1,7 @@
 import { CancelWorkflow } from "./cancel_workflow";
 import { HumanInputText, HumanInputSingleChoice, HumanInputMultipleChoice, HumanOperate } from "./human";
 import { SummaryWorkflow } from "./summary_workflow";
+import { DocumentAgentTool } from "./document_agent";
 
 export {
     CancelWorkflow,
@@ -9,4 +10,5 @@ export {
     HumanInputMultipleChoice,
     HumanOperate,
     SummaryWorkflow,
+    DocumentAgentTool,
 }

--- a/src/universal_tools/summary_workflow.ts
+++ b/src/universal_tools/summary_workflow.ts
@@ -8,13 +8,17 @@ export class SummaryWorkflow implements Tool<SummaryWorkflowInput, any> {
 
   constructor() {
     this.name = 'summary_workflow';
-    this.description = 'Summarize briefly what this workflow has accomplished.';
+    this.description = 'Based on the completion of the task assigned by the user, generate the following:\n1. Start by expressing the task status, informing the user whether the task was successfully completed.\n2. Then, briefly and clearly describe the specific outcome of the task.';
     this.input_schema = {
       type: 'object',
       properties: {
+        isSuccessful: {
+          type: 'boolean',
+          description: '`true` if the workflow ultimately executes successfully, and `false` when the workflow ultimately fails, regardless of whether there are errors during the workflow.'
+        },
         summary: {
           type: 'string',
-          description: 'Your summary in markdown format.',
+          description: 'Your summary in markdown format, include task status and outcome of the task.',
         },
       },
       required: ['summary'],
@@ -25,9 +29,11 @@ export class SummaryWorkflow implements Tool<SummaryWorkflowInput, any> {
     if (typeof params !== 'object' || params === null || !params.summary) {
       throw new Error('Invalid parameters. Expected an object with a "summary" property.');
     }
-    const summary = params.summary;
-    console.log("summary: " + summary);
-    await context.callback?.hooks.onSummaryWorkflow?.(summary);
+    console.log("isSuccessful: " + params.isSuccessful);
+    console.log("summary: " + params.summary);
+    context.variables.set("workflow_is_successful", params.isSuccessful);
+    context.variables.set("workflow_summary", params.summary);
+    await context.callback?.hooks.onSummaryWorkflow?.(params.summary);
     return {status: "OK"};
   }
 }

--- a/src/universal_tools/write_context.ts
+++ b/src/universal_tools/write_context.ts
@@ -1,0 +1,35 @@
+import { Tool, InputSchema, ExecutionContext } from "@/types";
+
+export class WriteContextTool implements Tool<any, any> {
+  name = 'write_context';
+  description =
+    'Write a value to the global workflow context. Use this to store important intermediate results, but only when a piece of information is essential for future reference but missing from the final output specification of the current action.';
+  input_schema = {
+    type: 'object',
+    properties: {
+      key: {
+        type: 'string',
+        description: 'The key to store the value under',
+      },
+      value: {
+        type: 'string',
+        description: 'The value to store (must be JSON stringified if object/array)',
+      },
+    },
+    required: ['key', 'value'],
+  } as InputSchema;
+
+  async execute(context: ExecutionContext, params: unknown): Promise<unknown> {
+    const { key, value } = params as { key: string; value: string };
+    try {
+      // Try to parse the value as JSON
+      const parsedValue = JSON.parse(value);
+      context.variables.set(key, parsedValue);
+    } catch {
+      // If parsing fails, store as string
+      context.variables.set(key, value);
+    }
+    return { success: true, key, value };
+  }
+}
+


### PR DESCRIPTION
**注意：这个 PR 修改了 `Eko.execute` 的签名，请下游调用者注意适配。**

这个 PR 增加了 Workflow Result 的功能，让工作流结束时返回一个结果，包括以下字段：
1. `isSuccessful`：指示工作流最终是否执行成功；
2. `summary`：对工作流本身的简短的总结；
3. `payload`：工作流的产物，目前支持纯文本产物，同时预留了其他格式产物的类型，当工作流需要返回结果时（例如“给我生成一个述职报告”）非空，当工作流不需要返回结果时（例如“帮我打开 OpenAI 的官网”）为空，

以下是实现思路：
1. 新增`WorkflowResult`类型，涵盖以上字段；
2. 新增`DocumentAgentToolInput`工具，让它实现文书 Agent 工作，负责生成纯文本产物，通过修改工具的 `description` 来提示模型在合适的时候调用；
3. 修改`SummaryWorkflow`工具，新增输入参数`isSuccessful`，并微调 prompt；
4. 新增关于`context.variables`的写入逻辑：`DocumentAgentToolInput`工具会把返回值写入`workflow_transcript`键中，`SummaryWorkflow`工具会把返回值写入`workflow_is_successful`和`workflow_summary`中；
5. 新增关于`context.variables`的读取逻辑：`WorkflowImpl.execute`方法会读取`workflow_is_successful`, `workflow_summary`, `workflow_transcript`的值并组装成`WorkflowResult`类型的值。

以下是主要的修改：
1. `Eko.execute`方法和`WorkflowImpl.execute`方法的返回类型修改为`Promise<WorkflowResult>`，不再返回`Promise<NodeOutput[]>`；
2. 修改了生成工作流时的 system prompt（见`createWorkflowPrompts()`），使其不再工作流最后加入一个 Workflow Summary 的节点，而且不允许使用`summary_workflow`工具；
3. 在`WorkflowGenerator.doGenerateWorkflow`方法中，把一个 Workflow Summary 的节点通过硬编码的形式加入工作流；
4. 新增接口/类型：`WorkflowResult`, `WorkflowTranscript`, `WorkflowArtifact`, `DocumentAgentToolInput`, `DocumentAgentToolOutput`；
5. 修改接口：`SummaryWorkflowInput`新增了一个`isSuccessful: boolean`的字段；
6. 新增`DocumentAgentTool`工具，用来生成工作流产物（纯文本），通过详尽的参数利用大模型生成长文本；

你可以通过以下方式来验证这个 PR：
1. 构造一个需要输出长文本的任务 prompt（例如`Search Sam Altman's information on wikipedia and summarize it, you should only search 1 result`）并运行，期望行为是工作流返回值为 `WorkflowResult` 类型，且`isSuccessful`为`true`，`summary`为对工作流状态的简短总结，`payload` 为对 Sam Altman 的总结；
2. 构造一个不需要输出、只有操作的任务 prompt（例如`Open the official website of OpenAI for me`）并运行，期望行为是工作流返回值为 `WorkflowResult` 类型，且`isSuccessful`为`true`，`summary`为对工作流状态的简短总结，`payload` 为空。

---

**NOTE: This PR modifies the signature of `Eko.execute`. Please pay attention to compatibility for downstream callers.**

This PR enhances the functionality of Workflow Result, enabling it to return a result at the end of a workflow. The result includes the following fields:

1. `isSuccessful`: Indicates whether the workflow executed successfully in the end;
2. `summary`: A brief summary of the workflow itself;
3. `payload`: The output of the workflow. Currently, it supports plain text output and reserves types for outputs in other formats. The `payload` is non-empty when the workflow needs to return a result (e.g., "Generate a performance report for me") and empty when the workflow does not need to return a result (e.g., "Open the official website of OpenAI for me").

Here is the implementation plan:

1. Add a new `WorkflowResult` type, encompassing the above fields;
2. Introduce the `DocumentAgentToolInput` tool to handle document-related tasks and generate plain text outputs. The tool's `description` will be modified to prompt the model to invoke it at appropriate times;
3. Modify the `SummaryWorkflow` tool by adding an input parameter `isSuccessful` and slightly adjusting the prompt;
4. Add logic for writing to `context.variables`: The `DocumentAgentToolInput` tool writes the return value to the `workflow_transcript` key, while the `SummaryWorkflow` tool writes the return values to `workflow_is_successful` and `workflow_summary`;
5. Add logic for reading from `context.variables`: The `WorkflowImpl.execute` method reads the values of `workflow_is_successful`, `workflow_summary`, and `workflow_transcript` and assembles them into a `WorkflowResult` type value.

Here are the main changes:

1. The return types of the `Eko.execute` and `WorkflowImpl.execute` methods have been changed to `Promise<WorkflowResult>`, instead of `Promise<NodeOutput[]>`;
2. The system prompt when generating a workflow (see `createWorkflowPrompts()`) has been modified to no longer add a Workflow Summary node at the end of the workflow and to disallow the use of the `summary_workflow` tool;
3. In the `WorkflowGenerator.doGenerateWorkflow` method, a Workflow Summary node is hard-coded into the workflow;
4. New interfaces/types added: `WorkflowResult`, `WorkflowTranscript`, `WorkflowArtifact`, `DocumentAgentToolInput`, `DocumentAgentToolOutput`;
5. Interface modification: `SummaryWorkflowInput` has a new field `isSuccessful: boolean`;
6. Introduced the `DocumentAgentTool` to generate workflow outputs (plain text) by leveraging a large model with detailed parameters to generate long texts.

You can verify this PR by:

1. Creating a task prompt that requires outputting long text (e.g., "Search Sam Altman's information on Wikipedia and summarize it, you should only search 1 result") and running it. The expected behavior is that the workflow returns a `WorkflowResult` type value with `isSuccessful` as `true`, `summary` as a brief overview of the workflow status, and `payload` as a summary of Sam Altman;
2. Creating a task prompt that requires no output and only actions (e.g., "Open the official website of OpenAI for me") and running it. The expected behavior is that the workflow returns a `WorkflowResult` type value with `isSuccessful` as `true`, `summary` as a brief overview of the workflow status, and `payload` as empty.