### PR TITLE
fix: wrong configure logic about `EkoConfig`

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -3,6 +3,7 @@ import { WorkflowGenerator } from '../services/workflow/generator';
 import {
   LLMConfig,
   EkoConfig,
+  DefaultEkoConfig,
   EkoInvokeParam,
   LLMProvider,
   Tool,
@@ -27,15 +28,18 @@ export class Eko {
   constructor(llmConfig: LLMConfig, ekoConfig?: EkoConfig) {
     console.info("using Eko@" + process.env.COMMIT_HASH);
     this.llmProvider = LLMProviderFactory.buildLLMProvider(llmConfig);
-    
-    if (ekoConfig) {
-      this.ekoConfig = ekoConfig;
-    } else {
-      console.warn("`ekoConfig` is missing when construct `Eko` instance");
-      this.ekoConfig = { chromeProxy: chrome };
-    }
-    
+    this.ekoConfig = this.buildEkoConfig();
     this.registerTools();
+  }
+
+  private buildEkoConfig(ekoConfig?: Partial<EkoConfig>): EkoConfig {
+    if (!ekoConfig) {
+      console.warn("`ekoConfig` is missing when construct `Eko` instance");
+    }
+    return {
+      ...DefaultEkoConfig,
+      ...ekoConfig,
+    };
   }
 
   private registerTools() {

--- a/src/types/eko.types.ts
+++ b/src/types/eko.types.ts
@@ -28,6 +28,12 @@ export interface EkoConfig {
   callback?: WorkflowCallback,
 }
 
+export const DefaultEkoConfig: EkoConfig = {
+  workingWindowId: undefined,
+  chromeProxy: chrome,
+  callback: undefined,
+};
+
 export interface EkoInvokeParam {
   tools?: Array<string> | Array<Tool<any, any>>;
 }


### PR DESCRIPTION
这个 PR 修复了以下情况：当下游调用者在调用 `Eko.constructor` 时仅提供了一部分 `ekoConfig`（例如`{ callback: hookLogs() }`），`chrome`的值将会是 `undefined`，期望的值为`chrome`。

---

This PR fixes the following scenario: When a downstream caller provides only a partial `ekoConfig` (e.g., `{ callback: hookLogs() }`) when invoking `Eko.constructor`, the value of `chrome` will be `undefined`, whereas the expected value is `chrome`.