### PR TITLE
fix: the wrong signature in `buildEkoConfig`

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -28,11 +28,11 @@ export class Eko {
   constructor(llmConfig: LLMConfig, ekoConfig?: EkoConfig) {
     console.info("using Eko@" + process.env.COMMIT_HASH);
     this.llmProvider = LLMProviderFactory.buildLLMProvider(llmConfig);
-    this.ekoConfig = this.buildEkoConfig();
+    this.ekoConfig = this.buildEkoConfig(ekoConfig);
     this.registerTools();
   }
 
-  private buildEkoConfig(ekoConfig?: Partial<EkoConfig>): EkoConfig {
+  private buildEkoConfig(ekoConfig: Partial<EkoConfig> | undefined): EkoConfig {
     if (!ekoConfig) {
       console.warn("`ekoConfig` is missing when construct `Eko` instance");
     }


### PR DESCRIPTION
这个 PR 修复了`buildEkoConfig`的错误的函数签名，现在要求调用方必须提供 `ekoConfig` 参数。

---

This PR fixes the incorrect function signature of `buildEkoConfig`, and now requires the caller to provide the `ekoConfig` parameter.