### PR TITLE
Feature: more user side log

### DIFF
--- a/src/core/eko.ts
+++ b/src/core/eko.ts
@@ -28,11 +28,11 @@ export class Eko {
   constructor(llmConfig: LLMConfig, ekoConfig?: EkoConfig) {
     console.info("using Eko@" + process.env.COMMIT_HASH);
     this.llmProvider = LLMProviderFactory.buildLLMProvider(llmConfig);
-    this.ekoConfig = this.buildEkoConfig();
+    this.ekoConfig = this.buildEkoConfig(ekoConfig);
     this.registerTools();
   }
 
-  private buildEkoConfig(ekoConfig?: Partial<EkoConfig>): EkoConfig {
+  private buildEkoConfig(ekoConfig: Partial<EkoConfig> | undefined): EkoConfig {
     if (!ekoConfig) {
       console.warn("`ekoConfig` is missing when construct `Eko` instance");
     }

--- a/src/extension/tools/browser_use.ts
+++ b/src/extension/tools/browser_use.ts
@@ -81,6 +81,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
       if (params === null || !params.action) {
         throw new Error('Invalid parameters. Expected an object with a "action" property.');
       }
+      await context.callback?.hooks.logToolUsingDetail?.(this.name, `action: ${params.action}`);
       let tabId: number;
       try {
         tabId = await getTabId(context);
@@ -109,6 +110,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
           if (params.text == null) {
             throw new Error('text parameter is required');
           }
+          await context.callback?.hooks.logToolUsingDetail?.(this.name, `typing text: ${params.text}`);
           await browser.clear_input_by(context.ekoConfig.chromeProxy, tabId, selector_xpath, params.index);
           result = await browser.type_by(context.ekoConfig.chromeProxy, tabId, params.text, selector_xpath, params.index);
           await sleep(200);
@@ -143,6 +145,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
           break;
         case 'extract_content':
           let tab = await context.ekoConfig.chromeProxy.tabs.get(tabId);
+          await context.callback?.hooks.logToolUsingDetail?.(this.name, `extract the page content, wait a second...`);
           await injectScript(context.ekoConfig.chromeProxy, tabId);
           await sleep(200);
           let content = await executeScript(context.ekoConfig.chromeProxy, tabId, () => {
@@ -177,6 +180,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
           break;
         case 'screenshot_extract_element':
           console.log("execute 'screenshot_extract_element'...");
+          await context.callback?.hooks.logToolUsingDetail?.(this.name, `highlight the clickable elements...`);
           await sleep(100);
           console.log("injectScript...");
           await injectScript(context.ekoConfig.chromeProxy, tabId, 'build_dom_tree.js');
@@ -187,8 +191,10 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
           }, []);
           context.selector_map = element_result.selector_map;
           console.log("browser.screenshot...");
+          await context.callback?.hooks.logToolUsingDetail?.(this.name, `screenshot...`);
           let screenshot = await browser.screenshot(context.ekoConfig.chromeProxy, windowId, true);
           console.log("executeScript #2...");
+          await context.callback?.hooks.logToolUsingDetail?.(this.name, `remove highlight...`);
           await executeScript(context.ekoConfig.chromeProxy, tabId, () => {
             return (window as any).remove_highlight();
           }, []);

--- a/src/extension/tools/export_file.ts
+++ b/src/extension/tools/export_file.ts
@@ -100,6 +100,7 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
       await sleep(5000);
       await context.ekoConfig.chromeProxy.tabs.remove(tabId);
     }
+    await context.callback?.hooks.logToolUsingDetail?.(this.name, `file exported, press 'Ctrl+J' open the 'Downloads'`);
     return { success: true };
   }
 }

--- a/src/extension/tools/web_search.ts
+++ b/src/extension/tools/web_search.ts
@@ -48,7 +48,11 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
     }
     let taskId = new Date().getTime() + '';
     let searchs = [{ url: url as string, keyword: query as string }];
-    let searchInfo = await deepSearch(context, taskId, searchs, maxResults || 5, context.ekoConfig.workingWindowId);
+    let detailsMaxNum = maxResults || 5
+    await context.callback?.hooks.logToolUsingDetail?.(this.name, `search engine: "${url}"`);
+    await context.callback?.hooks.logToolUsingDetail?.(this.name, `search query: "${query}"`);
+    await context.callback?.hooks.logToolUsingDetail?.(this.name, `search items: "${detailsMaxNum}"`);
+    let searchInfo = await deepSearch(context, taskId, searchs, detailsMaxNum, context.ekoConfig.workingWindowId);
     let links = searchInfo.result[0]?.links || [];
     return links.filter((s: any) => s.content) as WebSearchResult[];
   }

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -109,7 +109,9 @@ export class ActionImpl implements Action {
       },
       onToolUse: async (toolCall) => {
         this.logger.log('info', `Assistant: ${assistantTextMessage}`);
+        await context.callback?.hooks.logAssistantReasoning?.(assistantTextMessage);
         this.logger.logToolExecution(toolCall.name, toolCall.input, context);
+        await context.callback?.hooks.logToolUsing?.(toolCall.name);
         hasToolUse = true;
 
         const tool = toolMap.get(toolCall.name);
@@ -390,6 +392,9 @@ export class ActionImpl implements Action {
       if (!hasToolUse && response) {
         // LLM sent a message without using tools - request explicit return
         this.logger.log('info', `Assistant: ${response.textContent}`);
+        if (response.textContent) {
+          await context.callback?.hooks.logAssistantReasoning?.(response.textContent);
+        }
         this.logger.log('warn', 'LLM sent a message without using tools; requesting explicit return');
         const returnOnlyParams = {
           ...params,

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -57,5 +57,8 @@ export interface WorkflowCallback {
     onHumanOperate?: (reason: string) => Promise<string>;
     onSummaryWorkflow?: (summary: string) => Promise<void>;
     onExportFile?: (param: ExportFileParam) => Promise<void>;
+    logAssistantReasoning?: (reasoning: string) => Promise<void>;
+    logToolUsing?: (toolName: string) => Promise<void>;
+    logToolUsingDetail?: (toolName: string, detail: string) => Promise<void>;
   }
 };


### PR DESCRIPTION
这个 PR 增加了更多的日志和对应的回调函数，方便应用层展示用户侧的日志。具体来说包括以下 3 个回调函数：
1. `logAssistantReasoning`：展示大模型思考过程；
2. `logToolUsing`：展示正在使用的工具的名称；
3. `logToolUsingDetail`：展示正在使用的工具的运行细节。

参考实现如下：
```typescript
      logToolUsing: async (toolName) => {
        printLog("Using the tool: " + toolName);
      },
      logAssistantReasoning: async (reasoning) => {
        printLog("Thinking: " + reasoning);
      },
      logToolUsingDetail: async (toolName, detail) => {
        printLog(`Detail of ${toolName}: ${detail}`);
      },
```

---

This PR adds more logs and corresponding callback functions to facilitate the display of user-side logs at the application layer. Specifically, it includes the following three callback functions:

1. `logAssistantReasoning`: Displays the thinking process of the large model;
2. `logToolUsing`: Displays the name of the tool currently in use;
3. `logToolUsingDetail`: Displays the operational details of the tool currently in use.

The reference implementation is as follows:
```typescript
logToolUsing: async (toolName: string) => {
  printLog("Using the tool: " + toolName);
},
logAssistantReasoning: async (reasoning: string) => {
  printLog("Thinking: " + reasoning);
},
logToolUsingDetail: async (toolName: string, detail: string) => {
  printLog(`Detail of ${toolName}: ${detail}`);
},
```