### PR TITLE
Fix: `getWindowId` and `getTabId`

### DIFF
--- a/src/extension/tools/browser_use.ts
+++ b/src/extension/tools/browser_use.ts
@@ -83,7 +83,9 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
       }
       let tabId: number;
       try {
+        console.log("getTabId(context)...");
         tabId = await getTabId(context);
+        console.log("getTabId(context)...done");
         if (!tabId || !Number.isInteger(tabId)) {
           throw new Error('Could not get valid tab ID');
         }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -49,16 +49,22 @@ export async function getTabId(context: ExecutionContext): Promise<number> {
   }
 
   if (!tabId) {
-    let windowId = context.variables.get('windowId') as any;
+    console.log("tabId is empty");
+    let windowId = await getWindowId(context);
+    console.log(`windowId=${windowId}`);
     if (windowId) {
       try {
         tabId = await getCurrentTabId(context.ekoConfig.chromeProxy, windowId);
+        console.log("getCurrentTabId(context.ekoConfig.chromeProxy, windowId) returns " + tabId);
       } catch (e) {
         tabId = await getCurrentTabId(context.ekoConfig.chromeProxy);
+        console.log("getCurrentTabId(context.ekoConfig.chromeProxy, windowId) throws an error");
+        console.log("getCurrentTabId(context.ekoConfig.chromeProxy) returns " + tabId);
         context.variables.delete('windowId');
       }
     } else {
       tabId = await getCurrentTabId(context.ekoConfig.chromeProxy);
+      console.log("getCurrentTabId(context.ekoConfig.chromeProxy) #2 returns " + tabId);
     }
 
     if (!tabId) {
@@ -72,30 +78,40 @@ export async function getTabId(context: ExecutionContext): Promise<number> {
 
 export function getCurrentTabId(chromeProxy: any, windowId?: number | undefined): Promise<number | undefined> {
   return new Promise((resolve, reject) => {
-    chromeProxy.tabs.query({ windowId, active: true, lastFocusedWindow: true }, function (tabs: any) {
-      if (chromeProxy.runtime.lastError) {
-        console.error('Chrome runtime error:', chromeProxy.runtime.lastError);
-        reject(chromeProxy.runtime.lastError);
-        return;
-      }
-      if (tabs.length > 0) {
-        resolve(tabs[0].id);
-      } else {
-        chromeProxy.tabs.query({ windowId, active: true, currentWindow: true }, function (_tabs: any) {
-          if (_tabs.length > 0) {
-            resolve(_tabs[0].id);
-            return;
-          } else {
-            chromeProxy.tabs.query(
-              { windowId, status: 'complete', currentWindow: true },
-              function (__tabs: any) {
-                resolve(__tabs.length ? __tabs[__tabs.length - 1].id : undefined);
-              }
-            );
-          }
-        });
-      }
-    });
+    console.debug("[getCurrentTabId] get the active tabId on: ", { windowId });
+    if (windowId !== undefined) {
+      console.debug(`[getCurrentTabId] get the active tab in window (windowId=${windowId})...`);
+      chromeProxy.tabs.query({ windowId, active: true }, (tabs: chrome.tabs.Tab[]) => {
+        if (chromeProxy.runtime.lastError) {
+          console.error(`[getCurrentTabId] failed to get: `, chromeProxy.runtime.lastError);
+          reject(chromeProxy.runtime.lastError);
+          return;
+        }
+        if (tabs.length > 0) {
+          console.debug(`[getCurrentTabId] found the tab, ID=${tabs[0].id}`);
+          resolve(tabs[0].id);
+        } else {
+          console.debug(`[getCurrentTabId] cannot find the tab, returns undefined`);
+          resolve(undefined);
+        }
+      });
+    } else {
+      console.debug(`[getCurrentTabId] get the active tabId on current window`);
+      chromeProxy.tabs.query({ active: true, currentWindow: true }, (tabs: chrome.tabs.Tab[]) => {
+        if (chromeProxy.runtime.lastError) {
+          console.error(`[getCurrentTabId] failed to get: `, chromeProxy.runtime.lastError);
+          reject(chromeProxy.runtime.lastError);
+          return;
+        }
+        if (tabs.length > 0) {
+          console.debug(`[getCurrentTabId] found the tab, ID=${tabs[0].id}`);
+          resolve(tabs[0].id);
+        } else {
+          console.debug(`[getCurrentTabId] cannot find the tab, returns undefined`);
+          resolve(undefined);
+        }
+      });
+    }
   });
 }
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -79,39 +79,28 @@ export async function getTabId(context: ExecutionContext): Promise<number> {
 export function getCurrentTabId(chromeProxy: any, windowId?: number | undefined): Promise<number | undefined> {
   return new Promise((resolve, reject) => {
     console.debug("[getCurrentTabId] get the active tabId on: ", { windowId });
+    let queryInfo: chrome.tabs.QueryInfo;
     if (windowId !== undefined) {
       console.debug(`[getCurrentTabId] get the active tab in window (windowId=${windowId})...`);
-      chromeProxy.tabs.query({ windowId, active: true }, (tabs: chrome.tabs.Tab[]) => {
-        if (chromeProxy.runtime.lastError) {
-          console.error(`[getCurrentTabId] failed to get: `, chromeProxy.runtime.lastError);
-          reject(chromeProxy.runtime.lastError);
-          return;
-        }
-        if (tabs.length > 0) {
-          console.debug(`[getCurrentTabId] found the tab, ID=${tabs[0].id}`);
-          resolve(tabs[0].id);
-        } else {
-          console.debug(`[getCurrentTabId] cannot find the tab, returns undefined`);
-          resolve(undefined);
-        }
-      });
+      queryInfo = { windowId, active: true };
     } else {
       console.debug(`[getCurrentTabId] get the active tabId on current window`);
-      chromeProxy.tabs.query({ active: true, currentWindow: true }, (tabs: chrome.tabs.Tab[]) => {
-        if (chromeProxy.runtime.lastError) {
-          console.error(`[getCurrentTabId] failed to get: `, chromeProxy.runtime.lastError);
-          reject(chromeProxy.runtime.lastError);
-          return;
-        }
-        if (tabs.length > 0) {
-          console.debug(`[getCurrentTabId] found the tab, ID=${tabs[0].id}`);
-          resolve(tabs[0].id);
-        } else {
-          console.debug(`[getCurrentTabId] cannot find the tab, returns undefined`);
-          resolve(undefined);
-        }
-      });
+      queryInfo = { active: true, currentWindow: true };
     }
+    chrome.tabs.query(queryInfo, (tabs: chrome.tabs.Tab[]) => {
+      if (chromeProxy.runtime.lastError) {
+        console.error(`[getCurrentTabId] failed to get: `, chromeProxy.runtime.lastError);
+        reject(chromeProxy.runtime.lastError);
+        return;
+      }
+      if (tabs.length > 0) {
+        console.debug(`[getCurrentTabId] found the tab, ID=${tabs[0].id}`);
+        resolve(tabs[0].id);
+      } else {
+        console.debug(`[getCurrentTabId] cannot find the tab, returns undefined`);
+        resolve(undefined);
+      }
+    });
   });
 }
 


### PR DESCRIPTION
这个 PR 尝试修复在执行 `getTabId` 函数时出现的 "Could not find a valid tab" 报错。这个 PR 做了以下修改：
1. 将`getTabId`函数中获取`windowId`的方式从`let windowId = context.variables.get('windowId') as any;`修改为`let windowId = await getWindowId(context);`；
2. 修改了`getCurrentTabId`的实现，现在它不再返回不期望的`undefined`了；
3. 添加了很多日志。

这个 PR 的验证需要很多“在当前标签页操作”的用例（例如“点开这个页面的第一个链接”）。

---

This PR attempts to fix the "Could not find a valid tab" error that occurs when executing the `getTabId` function. The following changes have been made in this PR:

1. The method of obtaining `windowId` in the `getTabId` function has been changed from `let windowId = context.variables.get('windowId') as any;` to `let windowId = await getWindowId(context);`.
2. The implementation of `getCurrentTabId` has been modified so that it no longer returns the undesired `undefined`.
3. Numerous logs have been added.

The verification of this PR requires numerous use cases involving "operating within the current tab" (e.g., "click on the first link on this page").