### PR TITLE
fix: add `url` to input_shema of `web_search`

### DIFF
--- a/src/extension/tools/web_search.ts
+++ b/src/extension/tools/web_search.ts
@@ -17,6 +17,10 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
     this.input_schema = {
       type: 'object',
       properties: {
+        url: {
+          type: 'string',
+          description: 'the URL of search engine, like https://www.bing.com'
+        },
         query: {
           type: 'string',
           description: 'search for keywords',
@@ -44,7 +48,7 @@ export class WebSearch implements Tool<WebSearchParam, WebSearchResult[]> {
     let query = params.query;
     let maxResults = params.maxResults;
     if (!url) {
-      url = 'https://www.google.com';
+      url = 'https://www.bing.com';
     }
     let taskId = new Date().getTime() + '';
     let searchs = [{ url: url as string, keyword: query as string }];


### PR DESCRIPTION
这个 PR 修复了 `web_search` 工具的 `input_shema` 的一个问题，即缺少`url`参数。此外还设置了默认的搜索引擎为 Bing，以便不方便访问 Google 的用户也能轻松运行 `web_search` 工具。

---

This PR fixes an issue with the `input_schema` of the `web_search` tool, which was missing the `url` parameter. Additionally, it sets the default search engine to Bing, making it easier for users who have difficulty accessing Google to run the `web_search` tool.