### PR TITLE
fix: descriptions of input_text in browser_use

### DIFF
--- a/src/extension/tools/browser_use.ts
+++ b/src/extension/tools/browser_use.ts
@@ -35,7 +35,7 @@ export class BrowserUse implements Tool<BrowserUseParam, BrowserUseResult> {
   - Screenshots are used to understand page layouts, with labeled bounding boxes corresponding to element indexes. Each bounding box and its label share the same color, with labels typically positioned in the top-right corner of the box.
   - Screenshots help verify element positions and relationships. Labels may sometimes overlap, so extracted elements are used to verify the correct elements.
   - In addition to screenshots, simplified information about interactive elements is returned, with element indexes corresponding to those in the screenshots.
-* \`input_text\`: Enter a string in the interactive element, If you need to press the Enter key, please end with '\\n'.
+* \`input_text\`: Enter a string in the interactive element, If you need to press the Enter key, please end with '\\n'. For search tasks, you MUST end with '\\n' to simulate pressing the Enter key.
 * \`click\`: Click to element.
 * \`right_click\`: Right-click on the element.
 * \`double_click\`: Double-click on the element.


### PR DESCRIPTION
更新 input_text 的prompt 明确搜索任务需要使用enter键的要求