### PR TITLE
Fix: Update Workflow Descriptions: Remove Node Limit & Increase Thinking Field Character Limit

### DIFF
--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -545,6 +545,11 @@ export class ActionImpl implements Action {
 ## HUMAN OPERATE:
 - When you need to log in or enter a verification code:
 1. First check if the user is logged in
+
+Please determine whether a user is logged in based on the front-end page elements. The analysis can be conducted from the following aspects:
+User Information Display Area: After logging in, the page will display user information such as avatar, username, and personal center links; if not logged in, it will show a login/register button.
+Navigation Bar or Menu Changes: After logging in, the navigation bar will include exclusive menu items like "My Orders" and "My Favorites"; if not logged in, it will show a login/register entry.
+
 2. If logged in, continue to perform the task normally
 3. If not logged in or encountering a verification code interface, immediately use the 'human_operate' tool to transfer the operation rights to the user
 4. On the login/verification code interface, do not use any automatic input tools (such as 'input_text') to fill in the password or verification code

--- a/src/schemas/workflow.schema.ts
+++ b/src/schemas/workflow.schema.ts
@@ -4,7 +4,7 @@ export const workflowSchema = {
   properties: {
     thinking: {
       type: "string",
-      description: 'Your thinking draft. Should start with "OK, now user requires me to ...". Just show your thinking process, DO NOT show the specificed steps,Remember DO NOT output more than 20 words total! You can use markdown format without code block.',
+      description: 'Your thinking draft. Should start with "OK, now user requires me to ...". Just show your thinking process, DO NOT show the specificed steps,Remember DO NOT output more than 50 words total! You can use markdown format without code block.',
     },
     id: { type: "string" },
     name: { type: "string" },

--- a/src/services/workflow/templates.ts
+++ b/src/services/workflow/templates.ts
@@ -29,7 +29,7 @@ export function createWorkflowGenerationTool(registry: ToolRegistry) {
   return {
     name: 'generate_workflow',
     description: `Generate a workflow following the Eko framework DSL schema.
-The workflow must  ensure proper dependencies between nodes.The number of nodes cannot exceed four.`,
+The workflow must  ensure proper dependencies between nodes.`,
     input_schema: {
       type: 'object',
       properties: {


### PR DESCRIPTION


- 在 workflow/templates.ts 中修改了 generate_workflow 的描述，去除了对节点数量的限制
- 在 workflow.schema.ts 中调整了 thinking 字段的描述，将输出字数限制从 20增加到 50