### PR TITLE
Fix: summarize workflow

### DIFF
--- a/src/common/summarize-workflow.ts
+++ b/src/common/summarize-workflow.ts
@@ -17,6 +17,7 @@ export async function summarizeWorkflow(
 
 - name: ${workflow.name}
 - description: ${workflow.description}
+- is successful?: ${contextVariables.get("__isSuccessful__")}
 - node:
 
 ${JSON.stringify(workflow.getRawWorkflowJson())}
@@ -41,10 +42,6 @@ ${JSON.stringify(nodeOutputs)}
       input_schema: {
         type: 'object',
         properties: {
-          isSuccessful: {
-            type: 'boolean',
-            description: '`true` if the workflow ultimately executes successfully, and `false` when the workflow ultimately fails, regardless of whether there are errors during the workflow.'
-          },
           summary: {
             type: 'string',
             description: 'Your summary in one paragraph with fluent and natural language, including task status and outcome of the task.',
@@ -70,7 +67,7 @@ ${JSON.stringify(nodeOutputs)}
   const response = await llmProvider.generateText(messages, params);
   console.log(response);
   return {
-    isSuccessful: response.toolCalls[0].input.isSuccessful as boolean,
+    isSuccessful: contextVariables.get("__isSuccessful__") as boolean,
     summary: response.toolCalls[0].input.summary as string,
     payload: response.toolCalls[0].input.document as string | undefined,
   };

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -29,6 +29,10 @@ function createReturnTool(
     input_schema: {
       type: 'object',
       properties: {
+        isSuccessful: {
+          type: 'boolean',
+          description: '`true` if the workflow ultimately executes successfully, and `false` when the workflow ultimately fails, regardless of whether there are errors during the workflow.'
+        },
         use_tool_result: {
           type: ['boolean'],
           description: `Whether to use the latest tool result as output. When set to true, the 'value' parameter is ignored.`,
@@ -48,6 +52,7 @@ function createReturnTool(
       console.info('debug the output...');
       console.log(params);
       console.info('debug the output...done');
+      context.variables.set("__isSuccessful__", (params as any).isSuccessful as boolean);
       return { success: true };
     },
   };


### PR DESCRIPTION
这个 PR 修复了以下问题：某些情况下工作流已经执行成功了，但是 summarize workflow 会因为上下文缺失/过长而返回 `isSuccessful=false`。我修改了 `return_output` 工具的入参，并在两个工具间强制同步`__isSuccessful__`变量来避免二者在这个问题上给出不同意见。