### PR TITLE
fix: remove unnecessary parameter passing when calling open_new_tab

### DIFF
--- a/src/extension/tools/export_file.ts
+++ b/src/extension/tools/export_file.ts
@@ -86,9 +86,9 @@ export class ExportFile implements Tool<ExportFileParam, unknown> {
       let tab;
       const url = 'https://www.google.com';
       if (context.ekoConfig.workingWindowId) {
-        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, false, context.ekoConfig.workingWindowId);
+        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, context.ekoConfig.workingWindowId);
       } else {
-        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, true);
+        tab = await open_new_tab(context.ekoConfig.chromeProxy, url);
       }
       context.callback?.hooks?.onTabCreated?.(tab.id as number);
       let tabId = tab.id as number;

--- a/src/extension/tools/open_url.ts
+++ b/src/extension/tools/open_url.ts
@@ -66,14 +66,14 @@ export class OpenUrl implements Tool<OpenUrlParam, OpenUrlResult> {
     let tab: chrome.tabs.Tab;
     if (newWindow) {
       console.log('Opening new tab in a new window.');
-      tab = await open_new_tab(context.ekoConfig.chromeProxy, url, true);
+      tab = await open_new_tab(context.ekoConfig.chromeProxy, url);
       context.callback?.hooks?.onTabCreated?.(tab.id as number);
       console.log('New tab created in a new window:', tab);
     } else {
       let windowId = context.ekoConfig.workingWindowId ? context.ekoConfig.workingWindowId : await getWindowId(context);
       console.log('Using existing window with ID:', windowId);
       try {
-        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, false, windowId);
+        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, windowId);
         console.log("Calling hook...")
         context.callback?.hooks?.onTabCreated?.(tab.id as number);
         console.log('New tab created in existing window:', tab);

--- a/src/extension/tools/tab_management.ts
+++ b/src/extension/tools/tab_management.ts
@@ -118,29 +118,12 @@ export class TabManagement implements Tool<TabManagementParam, TabManagementResu
       result = tabInfo;
     } else if (command.startsWith('new_tab')) {
       let url = command.replace('new_tab', '').replace('[', '').replace(']', '').replace(/"/g, '').trim();
-      // First mandatory opening of a new window
-      let newWindow = !context.variables.get('windowId') && !context.variables.get('tabId');
-      let tab: chrome.tabs.Tab;
-      if (newWindow) {
-        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, true);
-        context.callback?.hooks?.onTabCreated?.(tab.id as number);
-      } else {
-        let windowId = await getWindowId(context);
-        tab = await open_new_tab(context.ekoConfig.chromeProxy, url, false, windowId);
-        context.callback?.hooks?.onTabCreated?.(tab.id as number);
-      }
-      let windowId = tab.windowId as number;
+      let windowId = await getWindowId(context);
+      let tab = await open_new_tab(context.ekoConfig.chromeProxy, url, windowId);
+      context.callback?.hooks?.onTabCreated?.(tab.id as number);
       let tabId = tab.id as number;
       context.variables.set('windowId', windowId);
       context.variables.set('tabId', tabId);
-      if (newWindow) {
-        let windowIds = context.variables.get('windowIds') as Array<number>;
-        if (windowIds) {
-          windowIds.push(windowId);
-        } else {
-          context.variables.set('windowIds', [windowId] as Array<number>);
-        }
-      }
       let tabInfo: TabInfo = {
         tabId: tab.id,
         windowId: tab.windowId,

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -107,42 +107,24 @@ export function getCurrentTabId(chromeProxy: any, windowId?: number | undefined)
 export async function open_new_tab(
   chromeProxy: any,
   url: string,
-  newWindow: boolean,
   windowId?: number
 ): Promise<chrome.tabs.Tab> {
-  let tabId;
-  if (newWindow) {
-    let window = await chromeProxy.windows.create({
-      type: 'normal',
-      state: 'maximized',
-      url: url,
-    } as any as chrome.windows.CreateData);
-    windowId = window.id as number;
-    let tabs = window.tabs || [
-      await chromeProxy.tabs.create({
-        url: url,
-        windowId: windowId,
-      }),
-    ];
-    tabId = tabs[0].id as number;
-  } else {
-    if (!windowId) {
-      const window = await chromeProxy.windows.getCurrent();
-      windowId = window.id;
-    }
-    console.log("windowId: " + windowId);
-    let tab = await chromeProxy.tabs.create({
-      url: url,
-      windowId: windowId,
-    });
-    console.log("chromeProxy.tabs.create() done");
-    tabId = tab.id as number;
+  if(!windowId){
+    const window = await chromeProxy.windows.getCurrent();
+    windowId = window.id;
   }
-  let tab = await waitForTabComplete(chromeProxy, tabId);
+  console.log("windowId: " + windowId);
+  let tab = await chromeProxy.tabs.create({
+    url: url,
+    windowId: windowId,
+  });
+  console.log("chromeProxy.tabs.create() done");
+  let tabId = tab.id as number;
+  let completedTab = await waitForTabComplete(chromeProxy, tabId);
   console.log("waitForTabComplete() done");
   await sleep(200);
   console.log("sleep() done");
-  return tab;
+  return completedTab;
 }
 
 export async function executeScript(chromeProxy: any, tabId: number, func: any, args: any[]): Promise<any> {


### PR DESCRIPTION
remove unnecessary parameter passing when calling open_new_tab