### PR TITLE
Fix: 'parallel_tool_calls' is only allowed when 'tools' are specified.

### DIFF
--- a/src/services/llm/openai-provider.ts
+++ b/src/services/llm/openai-provider.ts
@@ -210,7 +210,7 @@ export class OpenaiProvider implements LLMProvider {
       messages: _messages,
       tools: tools,
       tool_choice: tool_choice,
-      parallel_tool_calls: false,
+      parallel_tool_calls: tools ? false : undefined,
     };
   }
 


### PR DESCRIPTION
`document_agent` 工具调用了 LLM API，且没有提供 `tools` 参数，导致 API 报错：

```
{
  "error": {
    "message": "Invalid value for 'parallel_tool_calls': 'parallel_tool_calls' is only allowed when 'tools' are specified.",
    "type": "invalid_request_error",
    "param": "parallel_tool_calls",
    "code": null
  }
}
```

这个 PR 修复了这个问题，在传参时检查 `tools` 参数是否为空来决定 `parallel_tool_calls` 的值。

你可以通过以下方式来验证这个 PR：构造一个 prompt，让 Eko 使用 `document_agent` 工具，例如：`use 'document_agent' tool to write a fairy tale and output it directly`。