### PR TITLE
fix: add tool name to `onLlmMessageUserSidePrompt`

### DIFF
--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -202,7 +202,7 @@ export class ActionImpl implements Action {
               let input = unwrapped.toolCall.input;
               console.log("unwrapped", unwrapped);
               if (unwrapped.userSidePrompt) {
-                context.callback?.hooks.onLlmMessageUserSidePrompt?.(unwrapped.userSidePrompt);
+                context.callback?.hooks.onLlmMessageUserSidePrompt?.(unwrapped.userSidePrompt, toolCall.name);
               } else {
                 console.warn("LLM returns without `userSidePrompt`");
               }

--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -52,7 +52,7 @@ export interface WorkflowCallback {
     afterWorkflow?: (workflow: Workflow, variables: Map<string, unknown>) => Promise<void>;
     onTabCreated?: (tabId: number) => Promise<void>;
     onLlmMessage?: (textContent: string) => Promise<void>;
-    onLlmMessageUserSidePrompt?: (text: string) => Promise<void>;
+    onLlmMessageUserSidePrompt?: (text: string, toolName: string) => Promise<void>;
     onHumanInputText?: (question: string) => Promise<string>;
     onHumanInputSingleChoice?: (question: string, choices: string[]) => Promise<string>;
     onHumanInputMultipleChoice?: (question: string, choices: string[]) => Promise<string[]>;


### PR DESCRIPTION
这个 PR 给 `onLlmMessageUserSidePrompt` 回调函数增加了 `toolName` 参数。现在这个回调函数会同时提供大模型写的 userSidePrompt 和工具的名称。