### PR TITLE
feat: add 'include_usage' param in OpenAI API

### DIFF
--- a/src/services/llm/openai-provider.ts
+++ b/src/services/llm/openai-provider.ts
@@ -204,6 +204,7 @@ export class OpenaiProvider implements LLMProvider {
     }
     return {
       stream: stream,
+      stream_options: stream ? { include_usage: true } : undefined,
       model: params.model || this.defaultModel,
       max_tokens: params.maxTokens || 4096,
       temperature: params.temperature,


### PR DESCRIPTION
这个 PR 给 OpenAI 的 API 添加了 `include_usage` 参数，方便流式调用时统计 token 开销。