### PR TITLE
fix: set 'isSuccessful' as required

### DIFF
--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -44,7 +44,7 @@ function createReturnTool(
             'The output value. Only provide a value if the previous tool result is not suitable for the output description. Otherwise, leave this as null.',
         },
       } as unknown,
-      required: ['use_tool_result', 'value'],
+      required: ['isSuccessful', 'use_tool_result', 'value'],
     } as InputSchema,
 
     async execute(context: ExecutionContext, params: unknown): Promise<unknown> {


### PR DESCRIPTION
这个 PR 将 `return_output` 工具设置为必选参数，修复了 https://github.com/FellouAI/eko/pull/115 的错误。