### PR TITLE
feat: add some sleep()

### DIFF
--- a/src/extension/tools/browser_use.ts
+++ b/src/extension/tools/browser_use.ts
@@ -198,6 +198,7 @@ export class BrowserUse extends ToolReturnsScreenshot<BrowserUseParam> {
             let screenshot = await browser.screenshot(context.ekoConfig.chromeProxy, windowId, true);
             result = { image: screenshot.image, text: element_result.element_str };
           } finally {
+            await sleep(500);
             logger.debug("executeScript #2...");
             await executeScript(context.ekoConfig.chromeProxy, tabId, () => {
               return (window as any).remove_highlight();

--- a/src/extension/tools/tool_returns_screenshot.ts
+++ b/src/extension/tools/tool_returns_screenshot.ts
@@ -1,6 +1,7 @@
 import { BrowserUseResult, ExecutionContext, InputSchema, Tool } from "@/types";
 import { BrowserUse } from "./browser_use";
 import { logger } from "@/common/log";
+import { sleep } from "../utils";
 
 export abstract class ToolReturnsScreenshot<T> implements Tool<T, BrowserUseResult> {
   abstract name: string;
@@ -12,6 +13,7 @@ export abstract class ToolReturnsScreenshot<T> implements Tool<T, BrowserUseResu
     const realResult = await this.realExecute(context, params);
     logger.debug("debug realResult...");
     logger.debug(realResult);
+    await sleep(3000); // wait for page loding
     let instance = new BrowserUse();
     const image = await instance.realExecute(context, { action: "screenshot_extract_element" });
     return image;


### PR DESCRIPTION
这个 PR 增加了一些等待函数：
* 在标签页创建后`sleep(3000)`以便页面加载完成
* 在截图的标记移除前`sleep(500)`以便调试时方便查看截图的标记