### PR TITLE
Fix: `getTabId`

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -70,7 +70,12 @@ export async function getTabId(context: ExecutionContext): Promise<number> {
     }
 
     if (!tabId) {
-      throw new Error('Could not find a valid tab');
+      const fellouTabId = window.__FELLOU_TAB_ID__;
+      if (tabId) {
+        tabId = fellouTabId;
+      } else {
+        throw new Error('Could not find a valid tab');
+      }
     }
     context.variables.set('tabId', tabId);
   }


### PR DESCRIPTION
这个 PR 尝试使用 `window.__FELLOU_TAB_ID__` 修复了 `getTabId` 的一些问题。