### PR TITLE
fix: get 'existingTabs' before workflow running

### DIFF
--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -412,9 +412,11 @@ export class ActionImpl implements Action {
 
     // get already existing tabs as task background
     const currentWindow = await context.ekoConfig.chromeProxy.windows.getCurrent();
-    const existingTabs: chrome.tabs.Tab[] = await context.ekoConfig.chromeProxy.tabs.query({
+    let existingTabs: chrome.tabs.Tab[] = await context.ekoConfig.chromeProxy.tabs.query({
       windowId: currentWindow.id,
     });
+    existingTabs = existingTabs.filter((tab) => {tab.title && tab.url});
+    logger.debug("existingTabs:", existingTabs);
 
     // get patchs for task
     let patchs: PatchItem[] = [];


### PR DESCRIPTION
这个 PR 优化了在工作流执行前获取已存在标签页的逻辑，防止脏数据污染。