### PR TITLE
fix(transportFormatted): log 'logErrors' in more readable way

### DIFF
--- a/src/common/log.ts
+++ b/src/common/log.ts
@@ -3,7 +3,10 @@ import { ILogObj, IMeta, ISettings, Logger } from "tslog";
 function transportFormatted(logMetaMarkup: string, logArgs: unknown[], logErrors: string[], settings: ISettings<ILogObj>) {
   const logErrorsStr = (logErrors.length > 0 && logArgs.length > 0 ? "\n" : "") + logErrors.join("\n");
   settings.prettyInspectOptions.colors = settings.stylePrettyLogs;
-  console.log(logMetaMarkup, ...logArgs, logErrorsStr);
+  console.log(logMetaMarkup, ...logArgs);
+  logErrors.forEach(err => {
+    console.log(logMetaMarkup + err);
+  });
 }
 
 function formatMeta(logObjMeta?: IMeta): string {


### PR DESCRIPTION
这个 PR 修复了控制台展示报错时的样式问题。