### PR TITLE
fix(getWindowId): add 'context.ekoConfig.workingWindowId' as fallback

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -30,6 +30,9 @@ export async function getWindowId(context: ExecutionContext): Promise<number> {
   if (!windowId) {
     windowId = (window as any).FELLOU_WINDOW_ID;
   }
+  if (!windowId) {
+    windowId = context.ekoConfig.workingWindowId;
+  }
 
   if (!windowId) {
     logger.warn("`getWindowId()` returns " + windowId);


### PR DESCRIPTION
这个 PR 修改了 `getWindowId` 的实现，把`context.ekoConfig.workingWindowId`作为之前实现全部失败时最后的垫底值。