### PR TITLE
support browser shadow dom element click trigger

### DIFF
--- a/packages/eko-core/src/agent/browser/browser_labels.ts
+++ b/packages/eko-core/src/agent/browser/browser_labels.ts
@@ -736,13 +736,23 @@ function do_click(params: {
     }
     for (let n = 0; n < num_clicks; n++) {
       for (let i = 0; i < eventTypes.length; i++) {
-        const event = new MouseEvent(eventTypes[i], {
+        const eventType = eventTypes[i];
+
+        const event = new MouseEvent(eventType, {
           view: window,
           bubbles: true,
           cancelable: true,
           button, // 0 left; 1 middle; 2 right
         });
-        element.dispatchEvent(event);
+
+        if (eventType === 'click' && element.click) {
+          // support shadow dom element
+          element.click();
+        } else {
+          element.dispatchEvent(event);
+        }
+
+        element.focus?.();
       }
     }
     return true;


### PR DESCRIPTION
The child nodes in the shadow DOM root in the web component cannot trigger the click event

<img width="929" height="203" alt="image" src="https://github.com/user-attachments/assets/5aef7ac4-cc4c-4b47-9a85-450669ba4b02" />
