### PR TITLE
[build_dom_tree.ts]  For Shadow DOM elements, use more lenient criteria

### DIFF
--- a/packages/eko-core/src/agent/browser/build_dom_tree.ts
+++ b/packages/eko-core/src/agent/browser/build_dom_tree.ts
@@ -616,8 +616,12 @@ export function run_build_dom_tree() {
         nodeData.isVisible = isVisible;
         nodeData.isTopElement = isTop;
 
+        // For Shadow DOM elements, use more lenient criteria
+        const isInShadowDOM = node.getRootNode() instanceof ShadowRoot;
+        const shouldHighlight = isInteractive && isVisible && (isTop || isInShadowDOM);
+
         // Highlight if element meets all criteria and highlighting is enabled
-        if (isInteractive && isVisible && isTop) {
+        if (shouldHighlight) {
           nodeData.highlightIndex = highlightIndex++;
           window.clickable_elements[nodeData.highlightIndex] = node;
           if (doHighlightElements) {


### PR DESCRIPTION
在shadow dom 内的子元素，只需要可交互的、可见的判断，不需要isTopElement也认为是可高亮的吧，不然目前shadow dom root内的子元素都无法被识别到