### PR TITLE
fix: correct typos in documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Eko (pronounced like 'echo') is a production-ready JavaScript framework that ena
 | **Intervenability**                  | ✅    | ✅          | ❌            | ❌        | ❌      |
 | **Task Parallel** | ✅    | ❌          | ❌            | ❌        | ❌      |
 | **Development Efficiency**           | **High**  | Low      | Middle        | Middle    | Low    |
-| **Task Complexity**           | **High**  | High      | Low        | Middle    | Middle    | Middle       |
+| **Task Complexity**           | **High**  | High      | Low        | Middle    | Middle    |
 | **Open-source**                      | ✅    | ✅          | ✅            | ✅        | ❌      |
 | **Access to private web resources** | ✅ | ❌          | ❌            | ❌        | ❌      |
 
@@ -43,7 +43,7 @@ Eko (pronounced like 'echo') is a production-ready JavaScript framework that ena
 
 ## Quickstart
 
-> **Note**: Please refer to the [Eko Quickstart guide](https://eko.fellou.ai/docs/getting-started/quickstart/) guide for full instructions on how to run it.
+> **Note**: Please refer to the [Eko Quickstart guide](https://eko.fellou.ai/docs/getting-started/quickstart/) for full instructions on how to run it.
 
 > **Security Warning**
 > 

--- a/packages/eko-core/src/agent/browser/build_dom_tree.ts
+++ b/packages/eko-core/src/agent/browser/build_dom_tree.ts
@@ -3,7 +3,7 @@ export function run_build_dom_tree() {
   /**
    * Get clickable elements on the page
    *
-   * @param {*} doHighlightElements Is highlighted
+   * @param {*} doHighlightElements Whether elements should be highlighted
    * @param {*} includeAttributes [attr_names...]
    * @returns { element_str, selector_map }
    */

--- a/packages/eko-core/src/agent/llm.ts
+++ b/packages/eko-core/src/agent/llm.ts
@@ -143,7 +143,7 @@ export function convertToolResult(
             mediaType: content.mimeType || "image/png",
           });
         } else {
-          // Only the claude model supports returning images from tool results, while openai only supports text,
+          // Only the claude model supports returning images from tool results, while openai only supports text
           // Compatible with other AI models that do not support tool results as images.
           user_messages.push({
             role: "user",

--- a/packages/eko-core/test/llm/llm.test.ts
+++ b/packages/eko-core/test/llm/llm.test.ts
@@ -234,7 +234,7 @@ export async function testImageToolsPrompt(llm: "openai" | "claude") {
           },
         ],
       },
-      // Only the calude model supports returning images from tool results, while openai only supports text.
+      // Only the claude model supports returning images from tool results, while openai only supports text.
       ...((llm == "claude"
         ? [
             {


### PR DESCRIPTION
- Remove duplicate 'guide' from README.md note
- Fix duplicate 'Middle' in README.md comparison table
- Correct JSDoc parameter description in build_dom_tree.ts
- Fix 'calude' typo to 'claude' in llm.test.ts
- Remove trailing comma in comment in llm.ts