### PR TITLE
build: bump xmldom dependency to fix critical vulnerability

### DIFF
--- a/packages/eko-core/package.json
+++ b/packages/eko-core/package.json
@@ -50,7 +50,7 @@
     "@ai-sdk/openai-compatible": "^1.0.13",
     "@openrouter/ai-sdk-provider": "^1.1.2",
     "secure-json-parse": "^4.0.0",
-    "xmldom": "^0.6.0",
+    "@xmldom/xmldom":  "^0.9.8",
     "zod": "^4.0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/advisories/GHSA-crh6-fp67-6883 and https://github.com/advisories?query=xmldom more generally.