### PR TITLE
fix: buffer stdout in SimpleStdioMcpClient for split/batched JSON-RPC messages

### DIFF
--- a/packages/eko-nodejs/src/mcp/stdio.ts
+++ b/packages/eko-nodejs/src/mcp/stdio.ts
@@ -18,6 +18,7 @@ export class SimpleStdioMcpClient implements IMcpClient {
   private options?: SpawnOptionsWithoutStdio;
   private process: ChildProcessWithoutNullStreams | null = null;
   private requestMap: Map<string, (messageData: any) => void>;
+  private stdoutBuffer: string = "";
 
   constructor(
     command: string,
@@ -38,18 +39,29 @@ export class SimpleStdioMcpClient implements IMcpClient {
         this.process.kill();
       } catch (e) {}
     }
+    this.stdoutBuffer = "";
     this.process = spawn(this.command, this.args, this.options);
     this.process.stdout.on("data", (data) => {
-      const response = data.toString().trim();
-      Log.debug("MCP Client, onmessage", this.command, this.args, response);
-      if (!response.startsWith("{")) {
-        return;
-      }
-      const message = JSON.parse(response);
-      if (message.id) {
-        const callback = this.requestMap.get(message.id);
-        if (callback) {
-          callback(message);
+      this.stdoutBuffer += data.toString();
+      const lines = this.stdoutBuffer.split("\n");
+      // Keep the last (possibly incomplete) segment in the buffer
+      this.stdoutBuffer = lines.pop() || "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("{")) {
+          continue;
+        }
+        Log.debug("MCP Client, onmessage", this.command, this.args, trimmed);
+        try {
+          const message = JSON.parse(trimmed);
+          if (message.id) {
+            const callback = this.requestMap.get(message.id);
+            if (callback) {
+              callback(message);
+            }
+          }
+        } catch (e) {
+          Log.warn("MCP Client, failed to parse JSON message:", trimmed, e);
         }
       }
     });


### PR DESCRIPTION
Fixes #276

## What
Adds proper newline-delimited JSON buffering to  stdout parsing, replacing the naive single-message-per-data-event assumption.

## Why
Node.js stream  events do not guarantee message boundaries. The previous implementation called  directly on each raw  event, which:
1. **Crashes** when a JSON-RPC message is split across multiple  events (partial JSON)
2. **Drops messages** when multiple newline-delimited JSON messages arrive in a single  event (only the first would be parsed)

This is a well-known pitfall with Node.js child process stdout handling and becomes more likely with larger payloads or rapid-fire MCP tool responses.

## Changes
- Added a `stdoutBuffer` field to accumulate incoming data across `data` events
- Split buffered data on newlines, keeping the last (potentially incomplete) segment in the buffer
- Parse each complete line individually with error handling (`try/catch` + `Log.warn`)
- Reset buffer on reconnect to prevent stale data from a previous session