### PR TITLE
feat(example): add Exa-powered web search via ChatService

### DIFF
--- a/example/nodejs/package.json
+++ b/example/nodejs/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@eko-ai/eko": "workspace:*",
     "@eko-ai/eko-nodejs": "workspace:*",
+    "exa-js": "^2.11.0",
     "canvas": "^3.2.0",
     "glob": "^11.0.2",
     "keytar": "^7.9.0",

--- a/example/nodejs/src/exa-chat-service.ts
+++ b/example/nodejs/src/exa-chat-service.ts
@@ -1,0 +1,91 @@
+import Exa from 'exa-js';
+import { ChatService, uuidv4 } from '@eko-ai/eko';
+import { EkoMessage, WebSearchResult } from '@eko-ai/eko/types';
+
+/**
+ * ChatService implementation powered by Exa (https://exa.ai) for web search.
+ *
+ * Exa is an AI-native search engine that returns clean, structured results
+ * optimised for agent pipelines. Set the EXA_API_KEY environment variable
+ * before constructing this service.
+ *
+ * Usage:
+ *   import { ExaChatService } from './exa-chat-service';
+ *   global.chatService = new ExaChatService();
+ */
+export class ExaChatService implements ChatService {
+  private readonly exa: Exa;
+
+  public constructor(apiKey?: string) {
+    const key = apiKey ?? process.env.EXA_API_KEY;
+    if (!key) {
+      throw new Error(
+        'EXA_API_KEY is required. Get one at https://dashboard.exa.ai/api-keys'
+      );
+    }
+    this.exa = new Exa(key);
+    // Integration header for Exa usage tracking
+    const headers = (this.exa as any).headers;
+    if (headers && typeof headers.set === 'function') {
+      headers.set('x-exa-integration', 'eko');
+    }
+  }
+
+  // -- ChatService: message persistence (no-op, override if needed) ----------
+
+  public loadMessages(_chatId: string): Promise<EkoMessage[]> {
+    return Promise.resolve([]);
+  }
+
+  public addMessage(_chatId: string, _messages: EkoMessage[]): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public memoryRecall(_chatId: string, _prompt: string): Promise<string> {
+    return Promise.resolve('');
+  }
+
+  public async uploadFile(
+    file: { base64Data: string; mimeType: string; filename?: string },
+    _chatId: string,
+    _taskId?: string | undefined
+  ): Promise<{ fileId: string; url: string }> {
+    return {
+      fileId: uuidv4(),
+      url: file.base64Data.startsWith('data:')
+        ? file.base64Data
+        : `data:${file.mimeType};base64,${file.base64Data}`,
+    };
+  }
+
+  // -- ChatService: web search via Exa --------------------------------------
+
+  public async websearch(
+    _chatId: string,
+    query: string,
+    site?: string,
+    _language?: string,
+    maxResults?: number
+  ): Promise<WebSearchResult[]> {
+    const numResults = Math.min(maxResults ?? 10, 50);
+
+    const response = await this.exa.search(query, {
+      type: 'auto',
+      numResults,
+      contents: {
+        highlights: true,
+        text: true,
+      },
+      ...(site ? { includeDomains: [site] } : {}),
+    });
+
+    return response.results.map((result) => ({
+      title: result.title ?? '',
+      url: result.url,
+      snippet:
+        result.highlights?.join(' ') ??
+        (result.text ? result.text.slice(0, 300) : ''),
+      content: result.text ?? undefined,
+    }));
+  }
+}

--- a/example/nodejs/src/index.ts
+++ b/example/nodejs/src/index.ts
@@ -1,8 +1,9 @@
 import dotenv from "dotenv";
 import FileAgent from "./file-agent";
 import LocalCookiesBrowserAgent from "./browser";
+import { ExaChatService } from "./exa-chat-service";
 import { BrowserAgent } from "@eko-ai/eko-nodejs";
-import { Eko, Log, LLMs, Agent, AgentStreamMessage } from "@eko-ai/eko";
+import { Eko, Log, LLMs, Agent, AgentStreamMessage, global } from "@eko-ai/eko";
 
 dotenv.config();
 
@@ -44,6 +45,10 @@ function testBrowserLoginStatus() {
 
 async function run() {
   Log.setLevel(1);
+  // Enable Exa-powered web search (requires EXA_API_KEY in .env)
+  if (process.env.EXA_API_KEY) {
+    global.chatService = new ExaChatService();
+  }
   // Use local browser cookie login state, will read local Chrome's cookie and localStorage information
   // If a password dialog pops up, please enter your computer password and click "Always Allow"
   const agents: Agent[] = [


### PR DESCRIPTION
## Summary

- Adds `ExaChatService`, a drop-in `ChatService` implementation powered by [Exa](https://exa.ai) (AI-native search engine) so Eko's built-in `WebSearchTool` returns real, structured search results instead of empty arrays
- Uses the `exa-js` SDK v2 with `search()` + highlights for token-efficient agent pipelines
- Includes the `x-exa-integration: eko` header for integration-level usage tracking (see also [HKUDS/CLI-Anything#205](https://github.com/HKUDS/CLI-Anything/pull/205) for the same pattern in another open-source integration)
- Wires into the Node.js example with a single env var (`EXA_API_KEY`)

## How it works

Eko's `WebSearchTool` delegates to `global.chatService.websearch()`, which currently returns `[]` in the example `SimpleChatService`. This PR provides a real implementation:

```typescript
import { ExaChatService } from './exa-chat-service';
global.chatService = new ExaChatService(); // reads EXA_API_KEY from env
```

Exa results are mapped to Eko's `WebSearchResult` type (`title`, `url`, `snippet`, `content`), and highlights are used as the snippet for optimal token efficiency.

## Files changed

| File | Change |
|------|--------|
| `example/nodejs/src/exa-chat-service.ts` | New `ExaChatService` implementation |
| `example/nodejs/src/index.ts` | Wire up Exa when `EXA_API_KEY` is set |
| `example/nodejs/package.json` | Add `exa-js` dependency |

## Test plan

- [ ] Set `EXA_API_KEY` in `.env` and run the Node.js example
- [ ] Verify `WebSearchTool` returns Exa results (title, url, snippet, content)
- [ ] Verify example still works without `EXA_API_KEY` (graceful no-op)

## Get an API key

Free keys available at [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys)

---

*Disclosure: I work at Exa. Happy to iterate on feedback.*